### PR TITLE
[Bug] - Include missing dotenv dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,4 +8,5 @@ dependencies = [
   "openai",
   "jsonlines",
   "ipdb>=0.13.13",
+  "python-dotenv"
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -505,6 +505,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -537,6 +546,7 @@ dependencies = [
     { name = "ipdb" },
     { name = "jsonlines" },
     { name = "openai" },
+    { name = "python-dotenv" },
 ]
 
 [package.metadata]
@@ -546,6 +556,7 @@ requires-dist = [
     { name = "ipdb", specifier = ">=0.13.13" },
     { name = "jsonlines" },
     { name = "openai" },
+    { name = "python-dotenv" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #19 and includes missing 'python-dotenv' dependency for the environment.

Before I crash out because it was missing the dependency:

![Screenshot 2025-05-09 at 3 59 59 PM](https://github.com/user-attachments/assets/1bc160b0-a059-4167-b7d9-3fd384189a13)

Was able to boot up Flask after including `python-dotenv` in `pyproject.toml`:

![Screenshot 2025-05-09 at 4 00 59 PM](https://github.com/user-attachments/assets/c7685c63-8a6c-4119-af9c-40a768e8f377)
