### PR TITLE
Store session ID/key in localStorage

### DIFF
--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -32,7 +32,7 @@ export default function Chat() {
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  // initialize session id when component mounts
+  // Initialize session ID when component mounts
   useEffect(() => {
     const cachedSessionId = localStorage.getItem("sessionId");
     if (cachedSessionId === null) {

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -32,9 +32,16 @@ export default function Chat() {
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  // Initialize session ID when component mounts
+  // initialize session id when component mounts
   useEffect(() => {
-    setSessionId(generateSessionId());
+    const cachedSessionId = localStorage.getItem("sessionId");
+    if (cachedSessionId === null) {
+      const newSessionId = generateSessionId();
+      localStorage.setItem("sessionId", newSessionId);
+      setSessionId(newSessionId);
+    } else {
+      setSessionId(cachedSessionId);
+    }
   }, []);
 
   const handleFeedback = async (_messageId: string, betterText: string) => {


### PR DESCRIPTION
This PR partially resolves #33 and persists the session ID between browser sessions and browser refreshes using localStorage.

If we wish for a lower level of persistence (e.g., only within the same session and browser refreshes), we could switch to sessionStorage.

As mentioned in #33, new API endpoints would be needed to supply the conversation history using this session ID.