### PR TITLE
Feature: Export messages button

### DIFF
--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import ExportMessagesButton from "./pages/Chat/components/ExportMessagesButton";
 
 // Generate a random session ID
 const generateSessionId = (): string => {
@@ -14,7 +15,7 @@ const generateSessionId = (): string => {
   );
 };
 
-interface Message {
+export interface IMessage {
   role: "user" | "bot";
   content: string;
   messageId: string;
@@ -24,7 +25,7 @@ interface Message {
 
 export default function Chat() {
   const [text, setText] = useState("");
-  const [messages, setMessages] = useState<Message[]>([]);
+  const [messages, setMessages] = useState<IMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [sessionId, setSessionId] = useState<string>("");
   const [feedbackOpen, setFeedbackOpen] = useState<string | null>(null);
@@ -171,9 +172,12 @@ export default function Chat() {
 
   return (
     <div className="container">
-      <h1 className="text-3xl text-center mb-6 mt-5 text-[#4a90e2] hover:bd-[#3a7bc8]">
-        <strong>Tenant First Aid</strong>
-      </h1>
+      <div className="relative">
+        <h1 className="text-3xl text-center mb-6 mt-5 text-[#4a90e2] hover:bd-[#3a7bc8]">
+          <strong>Tenant First Aid</strong>
+        </h1>
+        <ExportMessagesButton messages={messages} />
+      </div>
       <div className="conversation">
         {messages.length > 0 ? (
           <div className="messages">

--- a/frontend/src/pages/Chat/components/ExportMessagesButton.tsx
+++ b/frontend/src/pages/Chat/components/ExportMessagesButton.tsx
@@ -1,0 +1,17 @@
+import type { IMessage } from "../../../Chat";
+import exportMessages from "../utils/exportHelper";
+
+interface Props {
+  messages: IMessage[];
+}
+
+export default function ExportMessagesButton({ messages }: Props) {
+  return (
+    <button
+      className="absolute top-0 right-0 px-6 py-1.5 bg-[#ddd] rounded-md cursor-pointer"
+      onClick={() => exportMessages(messages)}
+    >
+      Export
+    </button>
+  );
+}

--- a/frontend/src/pages/Chat/utils/exportHelper.ts
+++ b/frontend/src/pages/Chat/utils/exportHelper.ts
@@ -1,0 +1,42 @@
+import type { IMessage } from "../../../Chat";
+
+export default function exportMessages(messages: IMessage[]) {
+  if (messages.length < 2) return;
+
+  const newDocument = window.open("", "", "height=800,width=600");
+  const messageChain = messages
+    .map(
+      ({ role, content }) =>
+        `<p><strong>${
+          role.charAt(0).toUpperCase() + role.slice(1)
+        }</strong>: ${content}</p>`
+    )
+    .join("");
+
+  newDocument?.document.writeln(`
+    <html>
+    <head>
+      <title>Conversation History</title>
+      <style>
+        body {
+          font-family: sans-serif;
+          padding: 20px;
+        }
+        strong {
+          font-weight: bold;
+        }
+        p {
+          margin: 12px;
+        }
+      </style>
+    </head>
+    <body>
+      ${messageChain}
+    </body>
+    </html>
+  `);
+
+  newDocument?.document.close();
+  newDocument?.focus();
+  newDocument?.print();
+}


### PR DESCRIPTION
This PR resolves #27 by including a simple button that triggers the export of the ongoing messages using the browser's native print functionality. From there, users can save it as a PDF. Further changes to the styling and location of the button can be decided when the Figma design is ready.

The type for Messages was also changed to IMessages to help differentiate between interfaces/types and components.