### PR TITLE
fix: ignore data directory

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,3 +12,6 @@ dependencies = [
   "ipdb>=0.13.13",
   "python-dotenv",
 ]
+
+[tool.setuptools.packages.find]
+exclude = ["data*"]


### PR DESCRIPTION
Builds not working because of the new `data` directory added by local valkey setup. This change ignores the 'data' directory in setuptools.