### PR TITLE
Add about page

### DIFF
--- a/frontend/src/AboutPage.tsx
+++ b/frontend/src/AboutPage.tsx
@@ -1,0 +1,39 @@
+import { useNavigate } from "react-router-dom";
+
+export default function AboutPage() {
+    const navigate = useNavigate();
+
+    return (
+        <div className="max-w-2xl mx-auto my-8 p-8 bg-white rounded-lg shadow-md relative ">
+            <button
+                className="absolute top-2 left-4 flex items-center text-[#4a90e2] hover:text-[#3a7bc8] font-semibold cursor-pointer"
+                onClick={() => navigate(-1)}
+                aria-label="Go back"
+            >
+                <svg className="w-6 h-6 mr-2" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+                </svg>
+                Back
+            </button>
+            <h1 className="text-3xl font-bold mb-4 text-gray-800 mt-4 text-center">Tenant First Aid</h1>
+            <p className="mb-6 text-gray-700">
+                <strong>Tenant First Aid</strong> is an AI-powered chatbot designed to help tenants navigate rental issues, answer questions, and provides legal advice related to housing and eviction.
+            </p>
+            <h2 className="text-2xl font-semibold mt-6 mb-2 text-gray-800">Features</h2>
+            <ul className="list-disc list-inside mb-6 text-gray-700">
+                <li>Instant answers to common rental questions</li>
+                <li>Guidance on tenant rights and landlord obligations</li>
+                <li>Easy-to-use chat interface</li>
+                <li>Available 24/7</li>
+            </ul>
+            <h2 className="text-2xl font-semibold mt-6 mb-2 text-gray-800">How It Works</h2>
+            <p className="mb-6 text-gray-700">
+                Simply type your question or describe your situation, and Tenant First Aid will provide helpful information or direct you to relevant resources.
+            </p>
+            <h2 className="text-2xl font-semibold mt-6 mb-2 text-gray-800">Disclaimer</h2>
+            <p className="text-gray-600">
+                TenantFirst is an AI assistant and does not provide legal advice. For complex or urgent legal matters, please consult a qualified professional.
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Chat from "./Chat.tsx";
 import Feedback from "./Feedback.tsx";
 import PromptEditor from "./PromptEditor.tsx";
+import AboutPage from "./AboutPage.tsx"
 
 export default function App() {
   return (
@@ -10,6 +11,7 @@ export default function App() {
         <Route path="/" element={<Chat />} />
         <Route path="/feedback" element={<Feedback />} />
         <Route path="/prompt" element={<PromptEditor />} />
+        <Route path="/about" element={<AboutPage />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import ExportMessagesButton from "./pages/Chat/components/ExportMessagesButton";
+import { useNavigate } from "react-router-dom";
+
 
 // Generate a random session ID
 const generateSessionId = (): string => {
@@ -32,7 +34,7 @@ export default function Chat() {
   const [betterResponse, setBetterResponse] = useState("");
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
-
+  const navigate = useNavigate();
   // Initialize session ID when component mounts
   useEffect(() => {
     // Get chat history
@@ -210,128 +212,126 @@ export default function Chat() {
   }, [messages]);
 
   return (
-    <>
-      <div className="container">
-        <div className="relative">
-          <h1 className="text-3xl text-center mb-6 mt-5 text-[#4a90e2] hover:bd-[#3a7bc8]">
-            <strong>Tenant First Aid</strong>
-          </h1>
-          <ExportMessagesButton messages={messages} />
-        </div>
-        <div className="conversation">
-          {messages.length > 0 ? (
-            <div className="messages">
-              {messages.map((message) => (
-                <div
-                  key={message.messageId}
-                  className={`message ${message.role === "bot" ? "bot-message" : "user-message"
-                    }`}
-                >
-                  <div className="message-content">
-                    <strong>{message.role === "bot" ? "Bot: " : "You: "}</strong>
-                    {message.role === "bot" &&
-                      message.content === "" &&
-                      isLoading ? (
-                      <span className="dot-pulse">...</span>
-                    ) : (
-                      <span className="whitespace-pre-wrap">
-                        {message.content}
-                      </span>
-                    )}
-                  </div>
-
-                  {message.role === "bot" && message.showFeedback && (
-                    <div className="feedback-section">
-                      {message.feedbackSubmitted === true ? (
-                        <div className="feedback-submitted">
-                          <span className="text-green-700">
-                            Thank you for your feedback!
-                          </span>
-                        </div>
-                      ) : feedbackOpen === message.messageId ? (
-                        <div className="feedback-form">
-                          <textarea
-                            className="w-full p-3 border-1 border-[#ddd] rounded-md box-border transition-colors duration-300 focus:outline-0 focus:border-[#4a90e2] focus:shadow-[0_0_0_2px_rgba(74,144,226,0.2)]"
-                            placeholder="Describe the preferred behavior"
-                            value={betterResponse}
-                            onChange={(e) => setBetterResponse(e.target.value)}
-                            rows={4}
-                          />
-                          <div className="flex gap-2">
-                            <button
-                              className="py-1.5 px-4 bg-[#4a90e2] hover:bg-[#3a7bc8] text-white rounded-md cursor-pointer transition-color duration-300"
-                              onClick={() =>
-                                handleFeedback(message.messageId, betterResponse)
-                              }
-                              disabled={!betterResponse.trim()}
-                            >
-                              Submit
-                            </button>
-                            <button
-                              className="py-1.5 px-4 bg-[#ddd] text-[#333] rounded-md cursor-pointer transition-color duration-300"
-                              onClick={() => setFeedbackOpen(null)}
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        </div>
-                      ) : (
-                        <button
-                          onClick={() => setFeedbackOpen(message.messageId)}
-                          className="bg-none border-none cursor-pointer p-1 text-[#888]"
-                          title="Provide better response"
-                        >
-                          👎 This response could be better
-                        </button>
-                      )}
-                    </div>
+    <div className="container relative mx-auto flex flex-col">
+      <div className="relative">
+        <h1 className="text-3xl text-center mb-6 mt-5 text-[#4a90e2] hover:bd-[#3a7bc8]">
+          <strong>Tenant First Aid</strong>
+        </h1>
+        <ExportMessagesButton messages={messages} />
+      </div>
+      <div className="conversation">
+        {messages.length > 0 ? (
+          <div className="messages">
+            {messages.map((message) => (
+              <div
+                key={message.messageId}
+                className={`message ${message.role === "bot" ? "bot-message" : "user-message"
+                  }`}
+              >
+                <div className="message-content">
+                  <strong>{message.role === "bot" ? "Bot: " : "You: "}</strong>
+                  {message.role === "bot" &&
+                    message.content === "" &&
+                    isLoading ? (
+                    <span className="dot-pulse">...</span>
+                  ) : (
+                    <span className="whitespace-pre-wrap">
+                      {message.content}
+                    </span>
                   )}
                 </div>
-              ))}
-            </div>
-          ) : (
-            <p className="text-center text-[#888]">
-              Ask me anything about tenant rights and assistance.
-            </p>
-          )}
-        </div>
-        <div className="flex gap-2 mt-4 h-11 items-stretch">
-          <input
-            type="text"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault(); // prevent form submission or newline
-                handleSend();
-              }
-            }}
-            className="w-full p-3 border-1 border-[#ddd] rounded-md box-border transition-colors duration-300 focus:outline-0 focus:border-[#4a90e2] focus:shadow-[0_0_0_2px_rgba(74,144,226,0.2)]"
-            placeholder={
-              feedbackSubmitted
-                ? "Please refresh the page to start a new conversation"
-                : "Type your message here..."
+
+                {message.role === "bot" && message.showFeedback && (
+                  <div className="feedback-section">
+                    {message.feedbackSubmitted === true ? (
+                      <div className="feedback-submitted">
+                        <span className="text-green-700">
+                          Thank you for your feedback!
+                        </span>
+                      </div>
+                    ) : feedbackOpen === message.messageId ? (
+                      <div className="feedback-form">
+                        <textarea
+                          className="w-full p-3 border-1 border-[#ddd] rounded-md box-border transition-colors duration-300 focus:outline-0 focus:border-[#4a90e2] focus:shadow-[0_0_0_2px_rgba(74,144,226,0.2)]"
+                          placeholder="Describe the preferred behavior"
+                          value={betterResponse}
+                          onChange={(e) => setBetterResponse(e.target.value)}
+                          rows={4}
+                        />
+                        <div className="flex gap-2">
+                          <button
+                            className="py-1.5 px-4 bg-[#4a90e2] hover:bg-[#3a7bc8] text-white rounded-md cursor-pointer transition-color duration-300"
+                            onClick={() =>
+                              handleFeedback(message.messageId, betterResponse)
+                            }
+                            disabled={!betterResponse.trim()}
+                          >
+                            Submit
+                          </button>
+                          <button
+                            className="py-1.5 px-4 bg-[#ddd] text-[#333] rounded-md cursor-pointer transition-color duration-300"
+                            onClick={() => setFeedbackOpen(null)}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setFeedbackOpen(message.messageId)}
+                        className="bg-none border-none cursor-pointer p-1 text-[#888]"
+                        title="Provide better response"
+                      >
+                        👎 This response could be better
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-center text-[#888]">
+            Ask me anything about tenant rights and assistance.
+          </p>
+        )}
+      </div>
+      <div className="flex gap-2 mt-4 h-11 items-stretch">
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault(); // prevent form submission or newline
+              handleSend();
             }
-            disabled={isLoading || feedbackSubmitted}
-            ref={inputRef}
-          />
-          <button
-            className="px-6 bg-[#4a90e2] hover:bg-[#3a7bc8] text-white rounded-md cursor-pointer transition-color duration-300"
-            onClick={handleSend}
-            disabled={isLoading || !text.trim() || feedbackSubmitted}
-          >
-            {isLoading ? "..." : "Send"}
-          </button>
-        </div>
+          }}
+          className="w-full p-3 border-1 border-[#ddd] rounded-md box-border transition-colors duration-300 focus:outline-0 focus:border-[#4a90e2] focus:shadow-[0_0_0_2px_rgba(74,144,226,0.2)]"
+          placeholder={
+            feedbackSubmitted
+              ? "Please refresh the page to start a new conversation"
+              : "Type your message here..."
+          }
+          disabled={isLoading || feedbackSubmitted}
+          ref={inputRef}
+        />
+        <button
+          className="px-6 bg-[#4a90e2] hover:bg-[#3a7bc8] text-white rounded-md cursor-pointer transition-color duration-300"
+          onClick={handleSend}
+          disabled={isLoading || !text.trim() || feedbackSubmitted}
+        >
+          {isLoading ? "..." : "Send"}
+        </button>
       </div>
-      
-      <div className="flex justify-center">
-        <a
-            className="cursor-pointer font-bold underline text-[#E3574B] hover:text-[#B8473D] "
-            onClick={handleClearSession}
-            title="Clear Chat"
-          >Clear Chat</a>
-      </div>
-    </>
+      <button
+        className="fixed bottom-6 right-1/4 translate-x-1/2 sm:right-8 sm:translate-x-0 bg-white border border-[#4a90e2] text-[#4a90e2] hover:bg-[#4a90e2] hover:text-white rounded-full shadow-lg px-6 py-3 font-semibold transition-colors duration-300 cursor-pointer z-50"
+        onClick={() => navigate("/about")}
+        title="About Us"
+
+      >
+        About Tenant First Aid
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
# Summary
PR to add the first version of an "About Us" page

## Changes Made:

- Added an "About Us" button to the homepage.
- Linked the button to the `/about` route.
- Created a basic About page component.

## Note:
This is just the initial setup — it's currently unstyled and has placeholder content.  
More detailed content and styling will be added in a future update.

## Why:
This establishes the structure so others can contribute to the About page layout and content.

## Screenshots:
![image](https://github.com/user-attachments/assets/49990381-cd10-46ac-b36f-894f4cecef82)

![image](https://github.com/user-attachments/assets/1a55bd0a-50f7-4b00-b87e-cb4f66ea1863)

