### PR TITLE
Move sessionid to React Context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,17 +2,20 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Chat from "./Chat.tsx";
 import Feedback from "./Feedback.tsx";
 import PromptEditor from "./PromptEditor.tsx";
-import AboutPage from "./AboutPage.tsx"
+import AboutPage from "./AboutPage.tsx";
+import SessionContextProvider from "./contexts/SessionContext.tsx";
 
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Chat />} />
-        <Route path="/feedback" element={<Feedback />} />
-        <Route path="/prompt" element={<PromptEditor />} />
-        <Route path="/about" element={<AboutPage />} />
-      </Routes>
-    </Router>
+    <SessionContextProvider>
+      <Router>
+        <Routes>
+          <Route path="/" element={<Chat />} />
+          <Route path="/feedback" element={<Feedback />} />
+          <Route path="/prompt" element={<PromptEditor />} />
+          <Route path="/about" element={<AboutPage />} />
+        </Routes>
+      </Router>
+    </SessionContextProvider>
   );
 }

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useMemo, useState } from "react";
+import generateSessionId from "../pages/Chat/utils/sessionHelper";
+
+interface ISessionContextType {
+  sessionId: string;
+  setSessionId: React.Dispatch<React.SetStateAction<string>>;
+  handleNewSession: () => Promise<void>;
+}
+
+const SessionContext = createContext<ISessionContextType | null>(null);
+
+export { SessionContext };
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function SessionContextProvider({ children }: Props) {
+  const [sessionId, setSessionId] = useState("");
+
+  const handleNewSession = async () => {
+    const newSessionId = generateSessionId();
+    localStorage.setItem("sessionId", newSessionId);
+    setSessionId(newSessionId);
+  };
+
+  const sessionContextObject = useMemo(
+    () => ({ sessionId, setSessionId, handleNewSession }),
+    [sessionId]
+  );
+
+  return (
+    <SessionContext.Provider value={sessionContextObject}>
+      {children}
+    </SessionContext.Provider>
+  );
+}

--- a/frontend/src/hooks/useSession.tsx
+++ b/frontend/src/hooks/useSession.tsx
@@ -1,0 +1,12 @@
+import { use } from "react";
+import { SessionContext } from "../contexts/SessionContext";
+
+export default function useSession() {
+  const context = use(SessionContext);
+  if (context === null) {
+    throw new Error(
+      "useSession can only be used within SessionContextProvider"
+    );
+  }
+  return context;
+}

--- a/frontend/src/pages/Chat/components/InputField.tsx
+++ b/frontend/src/pages/Chat/components/InputField.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
 import { IMessage } from "../../../Chat";
+import useSession from "../../../hooks/useSession";
 
 interface Props {
   setMessages: React.Dispatch<React.SetStateAction<IMessage[]>>;
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   isLoading: boolean;
   feedbackSubmitted: boolean;
-  sessionId: string;
   inputRef: React.RefObject<HTMLInputElement | null>;
 }
 
@@ -15,10 +15,10 @@ export default function InputField({
   isLoading,
   setIsLoading,
   feedbackSubmitted,
-  sessionId,
   inputRef,
 }: Props) {
   const [text, setText] = useState("");
+  const { sessionId } = useSession();
 
   const handleSend = async () => {
     // If feedback was submitted, disable further interaction

--- a/frontend/src/pages/Chat/components/MessageFeedback.tsx
+++ b/frontend/src/pages/Chat/components/MessageFeedback.tsx
@@ -1,21 +1,21 @@
 import { useState } from "react";
 import { IMessage } from "../../../Chat";
+import useSession from "../../../hooks/useSession";
 
 interface Props {
   message: IMessage;
   setMessages: React.Dispatch<React.SetStateAction<IMessage[]>>;
-  sessionId: string;
   setFeedbackSubmitted: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function MessageFeedback({
   message,
   setMessages,
-  sessionId,
   setFeedbackSubmitted,
 }: Props) {
   const [feedbackOpen, setFeedbackOpen] = useState<string | null>(null);
   const [betterResponse, setBetterResponse] = useState("");
+  const { sessionId } = useSession();
 
   const handleFeedback = async (_messageId: string, betterText: string) => {
     if (!betterText.trim()) return;

--- a/frontend/src/pages/Chat/components/MessageWindow.tsx
+++ b/frontend/src/pages/Chat/components/MessageWindow.tsx
@@ -3,7 +3,7 @@ import { IMessage } from "../../../Chat";
 import InputField from "./InputField";
 import MessageContent from "./MessageContent";
 import MessageFeedback from "./MessageFeedback";
-import generateSessionId from "../utils/sessionHelper";
+import useSession from "../../../hooks/useSession";
 
 interface Props {
   messages: IMessage[];
@@ -17,7 +17,7 @@ export default function MessageWindow({
   isOngoing,
 }: Props) {
   const [isLoading, setIsLoading] = useState(false);
-  const [sessionId, setSessionId] = useState<string>("");
+  const { setSessionId, handleNewSession } = useSession();
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const messagesRef = useRef<HTMLDivElement | null>(null);
@@ -61,19 +61,15 @@ export default function MessageWindow({
 
     const cachedSessionId = localStorage.getItem("sessionId");
     if (cachedSessionId === null) {
-      const newSessionId = generateSessionId();
-      localStorage.setItem("sessionId", newSessionId);
-      setSessionId(newSessionId);
+      handleNewSession();
     } else {
       setSessionId(cachedSessionId);
       fetchChatHistory(cachedSessionId);
     }
-  }, [setMessages]);
+  }, [setMessages, setSessionId, handleNewSession]);
 
-  const handleClearSession = async () => {
-    const newSessionId = generateSessionId();
-    localStorage.setItem("sessionId", newSessionId);
-    setSessionId(newSessionId);
+  const handleClearSession = () => {
+    handleNewSession();
     setMessages([]);
   };
 
@@ -125,7 +121,6 @@ export default function MessageWindow({
                       <MessageFeedback
                         message={message}
                         setMessages={setMessages}
-                        sessionId={sessionId}
                         setFeedbackSubmitted={setFeedbackSubmitted}
                       />
                     )}
@@ -146,7 +141,6 @@ export default function MessageWindow({
           isLoading={isLoading}
           setIsLoading={setIsLoading}
           feedbackSubmitted={feedbackSubmitted}
-          sessionId={sessionId}
           inputRef={inputRef}
         />
         <div className="flex justify-center mt-4">


### PR DESCRIPTION
This PR resolves #64 and updates `sessionId` from using useState to React Context. Opens up the path for other potential contexts like notifications and messages. Also opens up the path for multiple sessions within the browser (e.g., storing a list of sessionIds for various chat sessions similar to ChatGPT)

Branch is built on top of PR #63. Can be merged after PR #63 to avoid a merge conflict