### PR TITLE
Minor styling updates and refactoring for mobile

### DIFF
--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -1,7 +1,7 @@
-import ExportMessagesButton from "./pages/Chat/components/ExportMessagesButton";
-import { useNavigate } from "react-router-dom";
-import MessageWindow from "./pages/Chat/components/MessageWindow";
 import { useState } from "react";
+import { Link } from "react-router-dom";
+import ExportMessagesButton from "./pages/Chat/components/ExportMessagesButton";
+import MessageWindow from "./pages/Chat/components/MessageWindow";
 
 export interface IMessage {
   role: "user" | "assistant";
@@ -15,32 +15,30 @@ export default function Chat() {
   const [messages, setMessages] = useState<IMessage[]>([]);
   const isOngoing = messages.length > 0;
 
-  const navigate = useNavigate();
-
   return (
-    <div className="h-screen flex items-center">
+    <div className="h-dvh flex items-center">
+      <ExportMessagesButton messages={messages} />
       <div
-        className={`container relative flex flex-col my-20 mx-auto p-6 bg-white rounded-lg shadow-[0_4px_6px_rgba(0,0,0,0.1)]
+        className={`container relative flex flex-col mx-auto p-6 bg-white rounded-lg shadow-[0_4px_6px_rgba(0,0,0,0.1)]
           ${
             isOngoing
-              ? "justify-between h-[calc(100vh-10rem)]"
+              ? "justify-between h-[calc(100dvh-10rem)]"
               : "justify-center max-w-[600px]"
           }`}
       >
-        <ExportMessagesButton messages={messages} />
         <MessageWindow
           messages={messages}
           setMessages={setMessages}
           isOngoing={isOngoing}
         />
-        <button
-          className="fixed bottom-6 right-1/4 translate-x-1/2 sm:right-8 sm:translate-x-0 bg-white border border-[#4a90e2] text-[#4a90e2] hover:bg-[#4a90e2] hover:text-white rounded-full shadow-lg px-6 py-3 font-semibold transition-colors duration-300 cursor-pointer z-50"
-          onClick={() => navigate("/about")}
-          title="About Us"
-        >
-          About Tenant First Aid
-        </button>
       </div>
+      <Link
+        className="fixed bottom-6 right-[8vw] px-6 py-1.5 bg-white border border-[#4a90e2] text-[#4a90e2] hover:bg-[#4a90e2] hover:text-white rounded-full shadow-lg font-semibold transition-colors duration-300 cursor-pointer z-50"
+        to="/about"
+        title="About Us"
+      >
+        About Tenant First Aid
+      </Link>
     </div>
   );
 }

--- a/frontend/src/pages/Chat/components/ExportMessagesButton.tsx
+++ b/frontend/src/pages/Chat/components/ExportMessagesButton.tsx
@@ -8,7 +8,7 @@ interface Props {
 export default function ExportMessagesButton({ messages }: Props) {
   return (
     <button
-      className="fixed top-6 right-[10vw] translate-x-1/2 px-6 py-1.5 bg-[#ddd] rounded-md border-1 cursor-pointer"
+      className="fixed top-6 right-[8vw] px-6 py-1.5 bg-[#ddd] rounded-full shadow-lg border cursor-pointer z-50"
       onClick={() => exportMessages(messages)}
     >
       Export

--- a/frontend/src/pages/Chat/components/MessageWindow.tsx
+++ b/frontend/src/pages/Chat/components/MessageWindow.tsx
@@ -88,7 +88,11 @@ export default function MessageWindow({
     <>
       <div>
         <div className="relative">
-          <h1 className="text-3xl text-center mb-6 mt-5 text-[#4a90e2] hover:bd-[#3a7bc8]">
+          <h1
+            className={`${
+              isOngoing ? "text-2xl" : "text-3xl"
+            } text-center mb-5 text-[#4a90e2]`}
+          >
             <strong>Tenant First Aid</strong>
           </h1>
         </div>


### PR DESCRIPTION
As the title suggest, this PR is for minor styling updates and refactoring of the Chat component.

The button to navigate to "about" is replaced with React Router's Link. The button to export the conversation also had its styling updated to match that of the link to "about". The spacing for existing components within Chat has been altered to make the display better for mobile.