### PR TITLE
Bug Fix: Chat history sync issue

### DIFF
--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import useSession from "./useSession";
 
@@ -36,8 +36,6 @@ async function addNewMessage(userMessage: string, sessionId: string) {
 }
 
 export default function useMessages() {
-  const queryClient = useQueryClient();
-
   const [messages, setMessages] = useState<IMessage[]>([]);
   const { sessionId } = useSession();
   const { data, isLoading, isError } = useQuery({
@@ -51,9 +49,6 @@ export default function useMessages() {
   const addMessage = useMutation({
     mutationFn: async (userMessage: string) => {
       return await addNewMessage(userMessage, sessionId);
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["messages", sessionId] });
     },
   });
 

--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -40,16 +40,13 @@ export default function useMessages() {
   const { sessionId } = useSession();
   const { data, isLoading, isError } = useQuery({
     queryKey: ["messages", sessionId],
-    queryFn: () => {
-      return fetchChatHistory(sessionId);
-    },
+    queryFn: async () => await fetchChatHistory(sessionId),
     enabled: !!sessionId,
   });
 
   const addMessage = useMutation({
-    mutationFn: async (userMessage: string) => {
-      return await addNewMessage(userMessage, sessionId);
-    },
+    mutationFn: async (userMessage: string) =>
+      await addNewMessage(userMessage, sessionId),
   });
 
   useEffect(() => {


### PR DESCRIPTION
This PR resolves #76 by patching up the bug related to the chat history. (See below)

https://github.com/user-attachments/assets/3c3c10a1-e17c-4b23-8df5-b768b465c51b

There seems to be a clash between how the data gets refetched from `addMessage` when mutated and how the chat history is fetched from `fetchChatHistory`, and removing `invalidateQueries` seems to fix the issue.