### PR TITLE
Include meta tag for export functionality

### DIFF
--- a/frontend/src/pages/Chat/utils/exportHelper.ts
+++ b/frontend/src/pages/Chat/utils/exportHelper.ts
@@ -16,6 +16,7 @@ export default function exportMessages(messages: IMessage[]) {
   newDocument?.document.writeln(`
     <html>
     <head>
+      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self';">
       <title>Conversation History</title>
       <style>
         body {


### PR DESCRIPTION
As suggested by Abdi during the May 28 meeting to add a meta tag to include CSP to see if we can patch vulnerability from export function.