### PR TITLE
Feature: Highlighting ORS Statutes from generated text

### DIFF
--- a/frontend/src/pages/Chat/components/MessageContent.tsx
+++ b/frontend/src/pages/Chat/components/MessageContent.tsx
@@ -1,7 +1,7 @@
 import type { IMessage } from "../../../hooks/useMessages";
 
 const orsRegex =
-  /ORS\s\d{2,3}\.\d+[A-Za-z]?(?:\(\d+\)(?:\([a-zA-Z0-9]+\))*)?(?:[-&]\d+[A-Za-z]?(?:\(\d+\)(?:\([a-zA-Z0-9]+\))*)?)?/g;
+  /(?:ORS\s*)?\d{2,3}\.\d+[A-Za-z]?(?:\(\d+\)(?:\([a-zA-Z0-9]+\))*)?(?:[-&](?:ORS\s*)?\d{2,3}\.\d+[A-Za-z]?(?:\(\d+\)(?:\([a-zA-Z0-9]+\))*)?)?/g;
 
 interface ORSProps {
   text: string;
@@ -17,7 +17,7 @@ function HighlightORS({ text }: ORSProps) {
     if (lastIndex < index) {
       parts.push(text.slice(lastIndex, index));
     }
-    const baseStatuteMatch = match[0].match(/ORS\s(\d{2,3}\.\d+)/);
+    const baseStatuteMatch = match[0].match(/(?:ORS\s*)?(\d{2,3}\.\d+)/);
     const baseStatute = baseStatuteMatch ? baseStatuteMatch[1] : "";
 
     parts.push(

--- a/frontend/src/pages/Chat/components/MessageContent.tsx
+++ b/frontend/src/pages/Chat/components/MessageContent.tsx
@@ -1,5 +1,45 @@
 import type { IMessage } from "../../../hooks/useMessages";
 
+const orsRegex =
+  /ORS\s\d{2,3}\.\d+[A-Za-z]?(?:\(\d+\)(?:\([a-zA-Z0-9]+\))*)?(?:[-&]\d+[A-Za-z]?(?:\(\d+\)(?:\([a-zA-Z0-9]+\))*)?)?/g;
+
+interface ORSProps {
+  text: string;
+}
+
+function HighlightORS({ text }: ORSProps) {
+  const parts = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(orsRegex)) {
+    const { index } = match;
+    if (index === null) continue;
+    if (lastIndex < index) {
+      parts.push(text.slice(lastIndex, index));
+    }
+
+    parts.push(
+      <button
+        key={index}
+        className="text-blue-600 underline cursor-pointer"
+        onClick={() => {
+          console.log(match[0]);
+        }}
+      >
+        {match[0]}
+      </button>
+    );
+
+    lastIndex = index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return <>{parts}</>;
+}
+
 interface Props {
   message: IMessage;
   isLoading: boolean;
@@ -12,7 +52,9 @@ export default function MessageContent({ message, isLoading }: Props) {
       {message.role === "assistant" && message.content === "" && isLoading ? (
         <span className="animate-dot-pulse">...</span>
       ) : (
-        <span className="whitespace-pre-wrap">{message.content}</span>
+        <span className="whitespace-pre-wrap">
+          <HighlightORS text={message.content} />
+        </span>
       )}
     </>
   );

--- a/frontend/src/pages/Chat/components/MessageContent.tsx
+++ b/frontend/src/pages/Chat/components/MessageContent.tsx
@@ -17,17 +17,21 @@ function HighlightORS({ text }: ORSProps) {
     if (lastIndex < index) {
       parts.push(text.slice(lastIndex, index));
     }
+    const baseStatuteMatch = match[0].match(/ORS\s(\d{2,3}\.\d+)/);
+    const baseStatute = baseStatuteMatch ? baseStatuteMatch[1] : "";
 
     parts.push(
-      <button
+      <a
         key={index}
         className="text-blue-600 underline cursor-pointer"
         onClick={() => {
           console.log(match[0]);
         }}
+        href={`https://oregon.public.law/statutes/ors_${baseStatute}`}
+        target="_blank"
       >
         {match[0]}
-      </button>
+      </a>
     );
 
     lastIndex = index + match[0].length;

--- a/frontend/src/pages/Chat/components/MessageContent.tsx
+++ b/frontend/src/pages/Chat/components/MessageContent.tsx
@@ -9,11 +9,11 @@ interface ORSProps {
 
 function HighlightORS({ text }: ORSProps) {
   const parts = [];
+  const matches = Array.from(text.matchAll(orsRegex));
   let lastIndex = 0;
 
-  for (const match of text.matchAll(orsRegex)) {
-    const { index } = match;
-    if (index === null) continue;
+  matches.forEach((match) => {
+    const index = match.index!;
     if (lastIndex < index) {
       parts.push(text.slice(lastIndex, index));
     }
@@ -35,7 +35,7 @@ function HighlightORS({ text }: ORSProps) {
     );
 
     lastIndex = index + match[0].length;
-  }
+  });
 
   if (lastIndex < text.length) {
     parts.push(text.slice(lastIndex));


### PR DESCRIPTION
Partially address #35 by adding interactivity to the ORS statutes that the AI generates. (see below)

https://github.com/user-attachments/assets/ee51c675-ef74-493e-a012-cf2667872cd8

The subcomponent called HighlightORS expects statutes with a general pattern of `ORS <statute number and letters>` and places them within an anchor tag. For the time being, clicking on it will route the user to the general statute at oregon.public.law.

In the future, we'll want to expand on this so that it'll open up a drawer/menu of sorts which would provide additional information based on that statute by hitting an API endpoint. The direct link could also be moved within the drawer/menu instead of the direct link from the chat.