### PR TITLE
Feature: Add Statute Annotation Drawer

### DIFF
--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -1,35 +1,54 @@
 import { Link } from "react-router-dom";
+import { useState } from "react";
 import ExportMessagesButton from "./pages/Chat/components/ExportMessagesButton";
 import MessageWindow from "./pages/Chat/components/MessageWindow";
+import StatuteDrawer from "./pages/Chat/components/StatuteDrawer";
 import useMessages from "./hooks/useMessages";
 
 export default function Chat() {
   const { messages, setMessages, isLoading, isError } = useMessages();
   const isOngoing = messages.length > 0;
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selectedStatute, setSelectedStatute] = useState<string | null>(null);
+
+  const handleStatuteClick = (statute: string) => {
+    setSelectedStatute(statute);
+    setDrawerOpen(true);
+  };
+
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    setSelectedStatute(null);
+  };
 
   return (
-    <div className="h-dvh flex items-center">
+    <div className="h-dvh pt-16 flex items-center">
       <ExportMessagesButton messages={messages} />
-      <div
-        className={`container relative flex flex-col mx-auto p-6 bg-white rounded-lg shadow-[0_4px_6px_rgba(0,0,0,0.1)]
-          ${
-            isOngoing
-              ? "justify-between h-[calc(100dvh-10rem)]"
-              : "justify-center max-w-[600px]"
-          }`}
-      >
-        {isLoading ? (
-          <div className={`${isLoading && "animate-dot-pulse"} text-center`}>
-            Loading...
+      <div className="flex w-full h-full">
+        <div className="flex-1 transition-all duration-300">
+          <div
+            className={`container relative flex flex-col mx-auto p-6 bg-white rounded-lg shadow-[0_4px_6px_rgba(0,0,0,0.1)]
+              ${isOngoing
+                ? "justify-between h-[calc(100dvh-10rem)]"
+                : "justify-center max-w-[600px]"
+              }`}
+          >
+            {isLoading ? (
+              <div className={`${isLoading && "animate-dot-pulse"} text-center`}>
+                Loading...
+              </div>
+            ) : (
+              <MessageWindow
+                messages={messages}
+                setMessages={setMessages}
+                isOngoing={isOngoing}
+                isError={isError}
+                onStatuteClick={handleStatuteClick}
+              />
+            )}
           </div>
-        ) : (
-          <MessageWindow
-            messages={messages}
-            setMessages={setMessages}
-            isOngoing={isOngoing}
-            isError={isError}
-          />
-        )}
+        </div>
+        <StatuteDrawer open={drawerOpen} statute={selectedStatute} onClose={closeDrawer} />
       </div>
       <Link
         className="fixed bottom-6 right-[8vw] px-6 py-1.5 bg-white border border-[#4a90e2] text-[#4a90e2] hover:bg-[#4a90e2] hover:text-white rounded-full shadow-lg font-semibold transition-colors duration-300 cursor-pointer z-50"

--- a/frontend/src/pages/Chat/components/MessageContent.tsx
+++ b/frontend/src/pages/Chat/components/MessageContent.tsx
@@ -5,9 +5,10 @@ const orsRegex =
 
 interface ORSProps {
   text: string;
+  onStatuteClick: (statute: string) => void;
 }
 
-function HighlightORS({ text }: ORSProps) {
+function HighlightORS({ text, onStatuteClick }: ORSProps) {
   const parts = [];
   const matches = Array.from(text.matchAll(orsRegex));
   let lastIndex = 0;
@@ -17,21 +18,17 @@ function HighlightORS({ text }: ORSProps) {
     if (lastIndex < index) {
       parts.push(text.slice(lastIndex, index));
     }
-    const baseStatuteMatch = match[0].match(/(?:ORS\s*)?(\d{2,3}\.\d+)/);
-    const baseStatute = baseStatuteMatch ? baseStatuteMatch[1] : "";
+
 
     parts.push(
-      <a
+      <p
         key={index}
-        className="text-blue-600 underline cursor-pointer"
-        onClick={() => {
-          console.log(match[0]);
-        }}
-        href={`https://oregon.public.law/statutes/ors_${baseStatute}`}
-        target="_blank"
+        className="inline text-blue-600 underline cursor-pointer transition-colors hover:bg-blue-200 rounded"
+        onClick={() => onStatuteClick(match[0])}
+
       >
         {match[0]}
-      </a>
+      </p>
     );
 
     lastIndex = index + match[0].length;
@@ -47,9 +44,14 @@ function HighlightORS({ text }: ORSProps) {
 interface Props {
   message: IMessage;
   isLoading: boolean;
+  onStatuteClick: (statute: string) => void;
 }
 
-export default function MessageContent({ message, isLoading }: Props) {
+export default function MessageContent({ message, isLoading, onStatuteClick }: Props) {
+
+
+
+
   return (
     <>
       <strong>{message.role === "assistant" ? "Bot: " : "You: "}</strong>
@@ -57,9 +59,10 @@ export default function MessageContent({ message, isLoading }: Props) {
         <span className="animate-dot-pulse">...</span>
       ) : (
         <span className="whitespace-pre-wrap">
-          <HighlightORS text={message.content} />
+          <HighlightORS text={message.content} onStatuteClick={onStatuteClick} />
         </span>
       )}
+
     </>
   );
 }

--- a/frontend/src/pages/Chat/components/MessageWindow.tsx
+++ b/frontend/src/pages/Chat/components/MessageWindow.tsx
@@ -5,11 +5,13 @@ import MessageContent from "./MessageContent";
 import MessageFeedback from "./MessageFeedback";
 import useSession from "../../../hooks/useSession";
 
+
 interface Props {
   messages: IMessage[];
   setMessages: React.Dispatch<React.SetStateAction<IMessage[]>>;
   isOngoing: boolean;
   isError: boolean;
+  onStatuteClick: (statute: string) => void;
 }
 
 export default function MessageWindow({
@@ -17,6 +19,7 @@ export default function MessageWindow({
   setMessages,
   isOngoing,
   isError,
+  onStatuteClick,
 }: Props) {
   const [isLoading, setIsLoading] = useState(false);
   const { setSessionId, handleNewSession } = useSession();
@@ -55,9 +58,8 @@ export default function MessageWindow({
       <div>
         <div className="relative">
           <h1
-            className={`${
-              isOngoing ? "text-2xl" : "text-3xl"
-            } text-center mb-5 text-[#4a90e2]`}
+            className={`${isOngoing ? "text-2xl" : "text-3xl"
+              } text-center mb-5 text-[#4a90e2]`}
           >
             <strong>Tenant First Aid</strong>
           </h1>
@@ -68,30 +70,31 @@ export default function MessageWindow({
           </div>
         ) : (
           <div
-            className={`max-h-[calc(100vh-25rem)] mx-auto max-w-[700px] ${
-              isOngoing ? "overflow-y-scroll" : "overflow-y-none"
-            }`}
+            className={`max-h-[calc(100vh-25rem)] mx-auto max-w-[700px] ${isOngoing ? "overflow-y-scroll" : "overflow-y-none"
+              }`}
             ref={messagesRef}
           >
             {isOngoing ? (
               <div className="flex flex-col gap-4">
                 {messages.map((message) => (
                   <div
-                    className={`flex w-full ${
-                      message.role === "assistant"
+                    className={`flex w-full ${message.role === "assistant"
                         ? "justify-start"
                         : "justify-end"
-                    }`}
+                      }`}
                     key={message.messageId}
                   >
                     <div
-                      className={`p-3 rounded-2xl max-w-[95%] ${
-                        message.role === "assistant"
+                      className={`p-3 rounded-2xl max-w-[95%] ${message.role === "assistant"
                           ? "bg-gray-100 rounded-tl-sm"
                           : "bg-[#4a90e2] text-white rounded-tr-sm"
-                      }`}
+                        }`}
                     >
-                      <MessageContent message={message} isLoading={isLoading} />
+                      <MessageContent
+                        message={message}
+                        isLoading={isLoading}
+                        onStatuteClick={onStatuteClick}
+                      />
                       {message.role === "assistant" && message.showFeedback && (
                         <MessageFeedback
                           message={message}

--- a/frontend/src/pages/Chat/components/StatuteDrawer.tsx
+++ b/frontend/src/pages/Chat/components/StatuteDrawer.tsx
@@ -1,0 +1,75 @@
+interface StatuteDrawerProps {
+    open: boolean;
+    statute: string | null;
+    onClose: () => void;
+}
+
+export default function StatuteDrawer({ open, statute, onClose }: StatuteDrawerProps) {
+    const baseStatuteMatch = statute?.match(/(?:ORS\s*)?(\d{2,3}\.\d+)/);
+    const baseStatute = baseStatuteMatch ? baseStatuteMatch[1] : "";
+
+    return (
+        <div
+            className={`
+                    fixed sm:static bottom-0 right-0
+                    transition-transform duration-500
+        ease-[cubic-bezier(.22,1.5,.36,1)] bg-white shadow-lg overflow-hidden
+                    w-full sm:w-96
+                    h-[70vh] sm:h-[calc(100dvh-10rem)]
+                    z-50
+                    ${open ? "translate-y-0 sm:translate-y-0" : "translate-y-full sm:hidden"}
+                    
+                `}
+        >
+            {open && (
+                <div className="relative h-full flex flex-col overflow-y-auto">
+                    <button
+                        className="absolute top-4 right-4 text-gray-500 hover:text-gray-800 cursor-pointer text-3xl leading-none"
+                        onClick={onClose}
+                        aria-label="Close"
+                    >
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            className="w-10 h-10 text-[#4a90e2]"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                        >
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                    <div className="p-8">
+                        <h2 className="text-xl font-bold mb-4">Statute Annotation</h2>
+                        {statute && (
+                            <div>
+                                <div className="font-mono text-blue-700 mb-2">{statute}</div>
+                                <a
+                                    href={`https://oregon.public.law/statutes/ors_${baseStatute}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-blue-600 underline hover:text-blue-800"
+                                >
+                                    View on Oregon Public Law
+                                </a>
+                                <p className="mt-4">
+                                    Annotation or details for <strong>{statute}</strong> go here.
+                                </p>
+                                <p>
+                                    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Facilis voluptates quia alias impedit aspernatur beatae eveniet quisquam adipisci veniam nam eum ex, id molestias itaque illum est expedita repudiandae corporis.
+                                    Dolorum placeat asperiores quis porro. Non et reprehenderit minima repellat sapiente itaque sed, perferendis harum cumque alias esse aliquid exercitationem commodi deleniti vitae debitis libero reiciendis aspernatur earum eum vero?
+                                    Dignissimos cum nulla numquam cupiditate modi iure ullam exercitationem obcaecati recusandae eum? Consequatur repudiandae illum quia. Nesciunt beatae nulla illum doloremque, dolorum voluptas neque, saepe, quo ex totam maxime? Nemo!
+                                    Suscipit excepturi quos, a laudantium atque, doloremque illum quaerat impedit tenetur quod quibusdam aperiam sapiente consequuntur dolores, praesentium tempora incidunt voluptate qui? Facilis corrupti culpa nobis repellendus doloremque quo laboriosam.
+                                    Sapiente reprehenderit aspernatur assumenda distinctio, magni in laudantium consequatur quod et! Unde cupiditate accusamus est eos possimus repellendus labore quaerat amet quo quod incidunt ipsum dolorum provident libero, recusandae consequuntur?
+                                    Illo, facere. Omnis reiciendis dolorem sit debitis harum, consequatur quisquam soluta velit, expedita eum mollitia culpa modi dolores perferendis, sed vitae vel totam? Animi qui facere placeat labore quam expedita.
+                                    Facere, deserunt quis. Animi quos omnis est ipsam eius sunt a totam distinctio atque. Alias necessitatibus temporibus in architecto. Omnis voluptate minima reiciendis ullam fugiat praesentium, accusamus id repudiandae aut?
+                                    Eius nisi quidem quae consequatur autem exercitationem labore nobis. Quas saepe iusto ratione corporis ipsa quae inventore fuga quos! Molestiae esse magni quasi! Debitis laudantium tenetur itaque officia quaerat. Minus.
+                                </p>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Relation to Other PRs

This PR is **based on** and **extends** [#84](https://github.com/org/repo/pull/123) (`issue-35/highlight-ors-statutes`).  
Please review and merge [#84](https://github.com/org/repo/pull/123) first, as this PR builds on top of its changes.

---
## Add StatuteDrawer Component

### Overview

introduce a new `StatuteDrawer` component 

### Key Changes

- **New `StatuteDrawer` component**
  - Slides in on desktop and mobile 
  -  provides a direct link to the relevant law.
  - Scrollable for long content.
  - Responsive design: acts as a sidebar on desktop and a bottom drawer on mobile.

### Files Changed

- `frontend/src/Chat.tsx`
- `frontend/src/pages/Chat/components/MessageContent.tsx`
- `frontend/src/pages/Chat/components/MessageWindow.tsx`
- `frontend/src/pages/Chat/components/StatuteDrawer.tsx` (new)

### Video:

https://github.com/user-attachments/assets/2dc953a6-8394-49f5-9902-eda15bd07a4e