### PR TITLE
fix: add VECTOR_STORE_ID to env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,8 @@ jobs:
             DB_PASSWORD=${{secrets.DB_PASSWORD}}
             DB_PORT=${{secrets.DB_PORT}}
             DB_USER=default
+            MODEL_REASONING_EFFORT=high
+            VECTOR_STORE_ID={{secrets.VECTOR_STORE_ID}}
             EOF
             chmod 640 /etc/tenantfirstaid/env
             


### PR DESCRIPTION
Adds the `VECTOR_STORE_ID` param to the `env` file setup in GH action.