### PR TITLE
Update site theme colors

### DIFF
--- a/frontend/src/AboutPage.tsx
+++ b/frontend/src/AboutPage.tsx
@@ -1,39 +1,54 @@
 import { useNavigate } from "react-router-dom";
 
 export default function AboutPage() {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    return (
-        <div className="mt-26 max-w-2xl mx-auto my-8 p-8 bg-white rounded-lg shadow-md relative ">
-            <button
-                className="absolute top-2 left-4 flex items-center text-[#4a90e2] hover:text-[#3a7bc8] font-semibold cursor-pointer"
-                onClick={() => navigate(-1)}
-                aria-label="Go back"
-            >
-                <svg className="w-6 h-6 mr-2" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-                </svg>
-                Back
-            </button>
-            <h1 className="text-3xl font-bold mb-4 text-gray-800 mt-4 text-center">Tenant First Aid</h1>
-            <p className="mb-6 text-gray-700">
-                <strong>Tenant First Aid</strong> is an AI-powered chatbot designed to help tenants navigate rental issues, answer questions, and provides legal advice related to housing and eviction.
-            </p>
-            <h2 className="text-2xl font-semibold mt-6 mb-2 text-gray-800">Features</h2>
-            <ul className="list-disc list-inside mb-6 text-gray-700">
-                <li>Instant answers to common rental questions</li>
-                <li>Guidance on tenant rights and landlord obligations</li>
-                <li>Easy-to-use chat interface</li>
-                <li>Available 24/7</li>
-            </ul>
-            <h2 className="text-2xl font-semibold mt-6 mb-2 text-gray-800">How It Works</h2>
-            <p className="mb-6 text-gray-700">
-                Simply type your question or describe your situation, and Tenant First Aid will provide helpful information or direct you to relevant resources.
-            </p>
-            <h2 className="text-2xl font-semibold mt-6 mb-2 text-gray-800">Disclaimer</h2>
-            <p className="text-gray-600">
-                TenantFirst is an AI assistant and does not provide legal advice. For complex or urgent legal matters, please consult a qualified professional.
-            </p>
-        </div>
-    );
+  return (
+    <div className="mt-26 max-w-2xl mx-auto my-8 p-8 bg-[#F4F4F2] rounded-lg shadow-md relative">
+      <button
+        className="absolute top-4 left-4 flex items-center text-[#4a90e2] hover:text-[#3a7bc8] font-semibold cursor-pointer"
+        onClick={() => navigate(-1)}
+        aria-label="Go back"
+      >
+        <svg
+          className="w-6 h-6 mr-2"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 19l-7-7 7-7"
+          />
+        </svg>
+        Back
+      </button>
+      <p className="my-6">
+        <strong>Tenant First Aid</strong> is an AI-powered chatbot designed to
+        help tenants navigate rental issues, answer questions, and provides
+        legal advice related to housing and eviction.
+      </p>
+      <h2 className="text-2xl font-semibold mt-6 mb-2">Features</h2>
+      <ul className="list-disc list-inside mb-6">
+        <li>Instant answers to common rental questions</li>
+        <li>Guidance on tenant rights and landlord obligations</li>
+        <li>Easy-to-use chat interface</li>
+        <li>Available 24/7</li>
+      </ul>
+      <h2 className="text-2xl font-semibold mt-6 mb-2">How It Works</h2>
+      <p className="mb-6">
+        Simply type your question or describe your situation, and Tenant First
+        Aid will provide helpful information or direct you to relevant
+        resources.
+      </p>
+      <h2 className="text-2xl font-semibold mt-6 mb-2">Disclaimer</h2>
+      <p className="">
+        <strong>Tenant First Aid</strong> is an AI assistant and does not
+        provide legal advice. For complex or urgent legal matters, please
+        consult a qualified professional.
+      </p>
+    </div>
+  );
 }

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -24,7 +24,7 @@ export default function Chat() {
       <div className="flex w-full items-center ">
         <div className="flex-1 transition-all duration-300">
           <div
-            className={`container relative flex flex-col mx-auto p-6 bg-white rounded-lg shadow-[0_4px_6px_rgba(0,0,0,0.1)]
+            className={`container relative flex flex-col mx-auto p-6 bg-[#F4F4F2] rounded-lg shadow-[0_4px_6px_rgba(0,0,0,0.1)]
               ${
                 isOngoing
                   ? "justify-between h-[calc(100dvh-10rem)]"

--- a/frontend/src/pages/Chat/components/ExportMessagesButton.tsx
+++ b/frontend/src/pages/Chat/components/ExportMessagesButton.tsx
@@ -8,7 +8,7 @@ interface Props {
 export default function ExportMessagesButton({ messages }: Props) {
   return (
     <button
-      className="py-2 px-4 border border-[#4a90e2] text-[#4a90e2] rounded-md font-semibold hover:bg-[#f0f6fb] transition-colors"
+      className="py-2 px-4 border border-[#4a90e2] text-[#4a90e2] rounded-md font-semibold hover:bg-[#E6F0FB] transition-colors cursor-pointer"
       onClick={() => exportMessages(messages)}
     >
       Export

--- a/frontend/src/pages/Chat/components/InputField.tsx
+++ b/frontend/src/pages/Chat/components/InputField.tsx
@@ -62,7 +62,6 @@ export default function InputField({
           )
         );
       }
-
     } catch (error) {
       console.error("Error:", error);
       setMessages((prev) =>
@@ -98,7 +97,7 @@ export default function InputField({
         ref={inputRef}
       />
       <button
-        className="px-6 bg-[#4a90e2] hover:bg-[#3a7bc8] text-white rounded-md cursor-pointer transition-color duration-300"
+        className="px-6 bg-[#1F584F] hover:bg-[#4F8B82] text-white rounded-md cursor-pointer transition-color duration-300"
         onClick={handleSend}
         disabled={isLoading || !text.trim()}
       >

--- a/frontend/src/pages/Chat/components/MessageWindow.tsx
+++ b/frontend/src/pages/Chat/components/MessageWindow.tsx
@@ -5,7 +5,6 @@ import MessageContent from "./MessageContent";
 import useSession from "../../../hooks/useSession";
 import ExportMessagesButton from "./ExportMessagesButton";
 
-
 interface Props {
   messages: IMessage[];
   setMessages: React.Dispatch<React.SetStateAction<IMessage[]>>;
@@ -54,41 +53,47 @@ export default function MessageWindow({
 
   return (
     <>
-      <div>
-
+      <div className="flex-1">
         {isError ? (
           <div className="flex items-center justify-center h-full text-center">
             Error fetching chat history. Try refreshing...
           </div>
         ) : (
           <div
-            className={`max-h-[calc(100vh-25rem)] mx-auto max-w-[700px] ${isOngoing ? "overflow-y-scroll" : "overflow-y-none"
-              }`}
+            className={`max-h-[calc(100vh-20rem)] mx-auto max-w-[700px] ${
+              isOngoing ? "overflow-y-scroll" : "overflow-y-none"
+            }`}
             ref={messagesRef}
           >
             {isOngoing ? (
               <div className="flex flex-col gap-4">
                 {messages.map((message) => (
                   <div
-                    className={`flex w-full ${message.role === "assistant"
-                      ? "justify-start"
-                      : "justify-end"
-                      }`}
+                    className={`flex w-full ${
+                      message.role === "assistant"
+                        ? "justify-start"
+                        : "justify-end"
+                    }`}
                     key={message.messageId}
                   >
                     <div
-                      className={`p-3 rounded-2xl max-w-[95%] ${message.role === "assistant"
-                        ? "bg-gray-100 rounded-tl-sm"
-                        : "bg-[#4a90e2] text-white rounded-tr-sm"
-                        }`}
+                      className={`p-3 rounded-2xl max-w-[95%] ${
+                        message.role === "assistant"
+                          ? "bg-slate-200 rounded-tl-sm"
+                          : "bg-[#1F584F] text-white rounded-tr-sm"
+                      }`}
                     >
-                      <MessageContent message={message} isLoading={isLoading} onStatuteClick={onStatuteClick} />
+                      <MessageContent
+                        message={message}
+                        isLoading={isLoading}
+                        onStatuteClick={onStatuteClick}
+                      />
                     </div>
                   </div>
                 ))}
               </div>
             ) : (
-              <p className="text-center text-[#888]">
+              <p className="text-center">
                 Ask me anything about tenant rights and assistance.
               </p>
             )}
@@ -105,22 +110,17 @@ export default function MessageWindow({
         {messages.length > 0 ? (
           <div className="flex justify-center gap-4 mt-4">
             <button
-              className="flex items-center gap-2 px-4 py-2 rounded-md border border-gray-300 bg-white text-[#E3574B] font-semibold shadow-sm hover:bg-[#fff0ee] hover:border-[#E3574B] transition-colors"
+              className="flex items-center gap-2 px-4 py-2 rounded-md border border-gray-300 text-[#E3574B] font-semibold shadow-sm hover:bg-[#fff0ee] hover:border-[#E3574B] transition-colors cursor-pointer"
               onClick={handleClearSession}
               title="Clear Chat"
             >
-
               Clear Chat
             </button>
             <div className="">
-              <ExportMessagesButton
-                messages={messages}
-
-              />
+              <ExportMessagesButton messages={messages} />
             </div>
           </div>
         ) : null}
-
       </div>
     </>
   );

--- a/frontend/src/pages/Chat/components/Navbar.tsx
+++ b/frontend/src/pages/Chat/components/Navbar.tsx
@@ -2,57 +2,73 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 
 export default function Navbar() {
-    const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
-    return (
-        <nav className="fixed top-0 left-0 w-full bg-white shadow-md py-3 px-6  z-50">
-            <div className="mx-auto flex items-center ">
-                <div className="m-auto flex items-center ">
+  return (
+    <nav className="fixed top-0 left-0 w-full bg-[#1F584F] shadow-md py-3 px-6 z-50">
+      <div className="mx-auto flex items-center ">
+        <div className="m-auto flex items-center ">
+          <Link to="/" className="text-2xl font-bold text-[#F4F4F2]">
+            Tenant First Aid
+          </Link>
+        </div>
+        <button
+          className="flex flex-col justify-center items-center w-10 h-10 relative z-60 cursor-pointer"
+          onClick={() => setSidebarOpen(!sidebarOpen)}
+          aria-label="Open menu"
+        >
+          <span
+            className={`block w-7 h-1 rounded transition-all duration-300 ${
+              sidebarOpen
+                ? "rotate-45 translate-y-2 bg-[#1F584F]"
+                : "bg-[#BACAB2]"
+            }`}
+          ></span>
+          <span
+            className={`block w-7 h-1 bg-[#BACAB2] rounded my-1 transition-all duration-300 ${
+              sidebarOpen ? "opacity-0" : ""
+            }`}
+          ></span>
+          <span
+            className={`block w-7 h-1 rounded transition-all duration-300 ${
+              sidebarOpen
+                ? "-rotate-45 -translate-y-2 bg-[#1F584F]"
+                : "bg-[#BACAB2]"
+            }`}
+          ></span>
+        </button>
+      </div>
 
-                    <Link to="/" className="text-2xl font-bold text-[#4a90e2]">
-                        Tenant First Aid
-                    </Link>
-                </div>
-                <button
-                    className="flex flex-col justify-center items-center w-10 h-10 relative z-60 cursor-pointer"
-                    onClick={() => setSidebarOpen(!sidebarOpen)}
-                    aria-label="Open menu"
-                >
-                    <span className={`block w-7 h-1 bg-[#4a90e2] rounded transition-all duration-300 ${sidebarOpen ? "rotate-45 translate-y-2" : ""}`}></span>
-                    <span className={`block w-7 h-1 bg-[#4a90e2] rounded my-1 transition-all duration-300 ${sidebarOpen ? "opacity-0" : ""}`}></span>
-                    <span className={`block w-7 h-1 bg-[#4a90e2] rounded transition-all duration-300 ${sidebarOpen ? "-rotate-45 -translate-y-2" : ""}`}></span>
-                </button>
-            </div>
+      <div
+        className={`fixed top-0 right-0 h-full w-64 bg-[#F4F4F2] shadow-lg z-50 transition-transform duration-300 ${
+          sidebarOpen ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div className="flex flex-col p-8 gap-6 mt-10">
+          <Link
+            to="/"
+            className="block px-3 py-2 rounded text-gray-700 font-medium transition-colors hover:bg-[#4F8B82] hover:text-[#F4F4F2]"
+            onClick={() => setSidebarOpen(false)}
+          >
+            Chat
+          </Link>
+          <Link
+            to="/about"
+            className="block px-3 py-2 rounded text-gray-700 font-medium transition-colors hover:bg-[#4F8B82] hover:text-[#F4F4F2]"
+            onClick={() => setSidebarOpen(false)}
+          >
+            About Tenant First Aid
+          </Link>
+          <hr className="my-2 border-t border-gray-300" />
+        </div>
+      </div>
 
-            <div
-                className={`fixed top-0 right-0 h-full w-64 bg-white shadow-lg z-50 transition-transform duration-300 ${sidebarOpen ? "translate-x-0" : "translate-x-full"
-                    }`}
-            >
-                <div className="flex flex-col p-8 gap-6 mt-10">
-                    <Link
-                        to="/"
-                        className="block px-3 py-2 rounded text-gray-700 font-medium transition-colors hover:bg-[#eaf4fb] hover:text-[#4a90e2]"
-                        onClick={() => setSidebarOpen(false)}
-                    >
-                        Chat
-                    </Link>
-                    <Link
-                        to="/about"
-                        className="block px-3 py-2 rounded text-gray-700 font-medium transition-colors hover:bg-[#eaf4fb] hover:text-[#4a90e2]"
-                        onClick={() => setSidebarOpen(false)}
-                    >
-                        About Tenant First Aid
-                    </Link>
-                    <hr className="my-2 border-t border-gray-300" />
-                </div>
-            </div>
-
-            {sidebarOpen && (
-                <div
-                    className="fixed inset-0 z-30"
-                    onClick={() => setSidebarOpen(false)}
-                />
-            )}
-        </nav>
-    );
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-30"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+    </nav>
+  );
 }

--- a/frontend/src/pages/Chat/components/StatuteDrawer.tsx
+++ b/frontend/src/pages/Chat/components/StatuteDrawer.tsx
@@ -34,7 +34,7 @@ export default function StatuteDrawer({
         <div
           className={`
             transition-transform duration-500 ease-[cubic-bezier(.22,1.5,.36,1)]
-            bg-white shadow-lg rounded
+            bg-[#F4F4F2] shadow-lg rounded
             h-[70vh] sm:h-full
             w-full
             ${
@@ -52,7 +52,7 @@ export default function StatuteDrawer({
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                className="w-10 h-10 text-[#4a90e2]"
+                className="w-10 h-10 text-[#1F584F]"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,11 +1,17 @@
 @import "tailwindcss";
 
+@layer base {
+  html,
+  body {
+    @apply bg-[#BACAB2];
+  }
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
     Ubuntu, Cantarell, sans-serif;
-  background: #f5f5f5;
-  color: #333;
+  color: #222829;
   line-height: 1.6;
 }
 


### PR DESCRIPTION
As discussed in today's meeting, I've begun migrating existing theme colors to what we have from our Figma boards. The changes to coloring include the Chat window, the About page, and the Navbar.

The main color palette used when updating the theme consists of the following colors:

![Screenshot 2025-06-11 at 11 45 49 PM](https://github.com/user-attachments/assets/bb4e8135-1536-4489-8596-f16801966de9)

The general coloring for existing utility buttons like Clear (#E3574B) and Export (#4A90E2) as well as for text highlighting for statutes remains untouched. The hover color for Export has been changed to a slightly darker hue to make the hover effect stand out more. (see visual changes below)

https://github.com/user-attachments/assets/61b99f04-b8e1-42ff-a803-81939e5ec7fc

Given that the message window utilizes #F4F4F2 as its background, I've opted to use #E2E8F0 to make the message from the bot stand out.

Other changes in this PR include minor padding/spacing changes to certain elements.
