### PR TITLE
add test for session.py

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,7 @@ build-backend = "setuptools.build_meta"
 dev = [
     "pytest>=8.3.5",
     "pytest-cov>=6.1.1",
+    "pytest-mock>=3.14.1",
     "ruff>=0.11.13",
     "ty>=0.0.1a8",
     "types-Flask>=1.1.6",

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -1,0 +1,54 @@
+import pytest
+from tenantfirstaid.session import TenantSession
+
+
+@pytest.fixture
+def mock_valkey(mocker):
+    """Mock the Valkey class with the db_con.ping(), db_con.get(), and db_con.set() methods."""
+    mock_client = mocker.Mock()
+    mocker.patch("tenantfirstaid.session.Valkey", return_value=mock_client)
+
+    _data = {}
+
+    mock_client.set = mocker.Mock(
+        side_effect=lambda key, value: _data.update({key: value})
+    )
+    mock_client.get = mocker.Mock(side_effect=lambda key: _data.get(key, None))
+    mock_client.ping = mocker.Mock()
+    return mock_client
+
+
+@pytest.fixture
+def mock_environ(monkeypatch):
+    monkeypatch.setenv("DB_HOST", "8.8.8.8")
+    monkeypatch.setenv("DB_PORT", "8888")
+    monkeypatch.setenv("DB_PASSWORD", "test_password")
+    monkeypatch.setenv("DB_USE_SSL", "false")
+
+
+def test_session_set_and_get(mock_valkey, mock_environ):
+    tenant_session = TenantSession()
+
+    mock_valkey.get.return_value = '"test_value"'
+    tenant_session.set("some_session_id", "test_value")
+    value = tenant_session.get("some_session_id")
+    assert value == "test_value"
+
+
+def test_session_get_unknown_session_id(mock_valkey, mock_environ):
+    tenant_session = TenantSession()
+
+    mock_valkey.get.return_value = None
+    value = tenant_session.get("some_session_id")
+    assert value == []
+
+
+def test_session_init_ping_exception(mocker, mock_environ, capsys):
+    # Patch Valkey so that ping raises an exception
+    mock_client = mocker.Mock()
+    mock_client.ping = mocker.Mock(side_effect=Exception("Ping failed"))
+    mocker.patch("tenantfirstaid.session.Valkey", return_value=mock_client)
+    # Should not raise, but print the exception
+    _obj = TenantSession()
+    captured = capsys.readouterr()
+    assert "Ping failed" in captured.out

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -683,6 +683,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241, upload-time = "2025-05-26T13:58:45.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923, upload-time = "2025-05-26T13:58:43.487Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -824,6 +836,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "ruff" },
     { name = "ty" },
     { name = "types-flask" },
@@ -850,6 +863,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "ruff", specifier = ">=0.11.13" },
     { name = "ty", specifier = ">=0.0.1a8" },
     { name = "types-flask", specifier = ">=1.1.6" },


### PR DESCRIPTION
coverage before ...
```
=== tests coverage ===
___ coverage: platform linux, python 3.12.3-final-0 ___

Name                          Stmts   Miss  Cover
-------------------------------------------------
tenantfirstaid/__init__.py        0      0   100%
tenantfirstaid/app.py            30      7    77%
tenantfirstaid/chat.py           63     44    30%
tenantfirstaid/citations.py      14      7    50%
tenantfirstaid/session.py        15      4    73%
tenantfirstaid/shared.py         11      0   100%
tests/test_import.py              4      0   100%
-------------------------------------------------
TOTAL                           137     62    55%
```

coverage after ...
```
=== tests coverage ===
___ coverage: platform linux, python 3.12.3-final-0 ___

Name                          Stmts   Miss  Cover
-------------------------------------------------
tenantfirstaid/__init__.py        0      0   100%
tenantfirstaid/app.py            30      7    77%
tenantfirstaid/chat.py           63     44    30%
tenantfirstaid/citations.py      14      7    50%
tenantfirstaid/session.py        15      0   100%
tenantfirstaid/shared.py         11      0   100%
tests/test_import.py              4      0   100%
tests/test_session.py            35      0   100%
-------------------------------------------------
TOTAL                           172     58    66%
=== 4 passed in 2.53s ===
```