### PR TITLE
Enhancement: Update CitySelectField state management

### DIFF
--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -20,8 +20,6 @@ export default function SessionContextProvider({ children }: Props) {
         method: "POST",
         credentials: "include",
       });
-      // Refresh the page to start fresh
-      window.location.reload();
     } catch (error) {
       console.error("Failed to clear session:", error);
       // Fallback: just refresh the page

--- a/frontend/src/pages/Chat/components/CitySelectField.tsx
+++ b/frontend/src/pages/Chat/components/CitySelectField.tsx
@@ -30,7 +30,6 @@ interface Props {
 
 export default function CitySelectField({ setMessages }: Props) {
   const [city, setCity] = useState<string | null>(null);
-  const [invalidCity, setInvalidCity] = useState<boolean>(false);
   const { initChat } = useMessages();
 
   const handleCityChange = async (key: string | null) => {
@@ -38,8 +37,6 @@ export default function CitySelectField({ setMessages }: Props) {
     const selectedCity =
       CitySelectOptions[key as keyof typeof CitySelectOptions];
     if (selectedCity && selectedCity.state) {
-      setInvalidCity(false);
-
       try {
         await initChat({ city: selectedCity.city, state: selectedCity.state });
 
@@ -56,17 +53,14 @@ export default function CitySelectField({ setMessages }: Props) {
         ]);
       } catch (error) {
         console.error("Error initializing session:", error);
-        setInvalidCity(true);
       }
-    } else {
-      setInvalidCity(true);
     }
   };
 
   return (
     <div className="flex flex-col gap-2">
       <p className="text-center text-[#888] mb-10">
-        {invalidCity
+        {city
           ? "Unfortunately we can only answer questions about tenant rights in Oregon right now."
           : "Welcome to Tenant First Aid! I can answer your questions about tenant rights in Oregon. To get started, what city are you located in?"}
       </p>


### PR DESCRIPTION
This PR provides minor updates to state management for `CitySelectField` by streamlining the number of states in the component. Functionality should be the same as before (see below).

https://github.com/user-attachments/assets/9e3330b2-3c06-4a79-85bd-020773927d9e

Other changes include removing browser reload from the try block for `handleNewSession` since the rendering of new session messages will be handled by the `initChat` function in `useMessages`. This would avoid additional re-renderings after clearing a chat session.