### PR TITLE
Update Oregon Law Center phone number to 888-585-9638

### DIFF
--- a/backend/scripts/eval.py
+++ b/backend/scripts/eval.py
@@ -24,7 +24,7 @@ samples = [
             2. Dispute the item with the credit bureau(s) in writing and attach a copy of the statute and your letter to the landlord.
             3. If the item isn’t deleted within 30 days, you can sue the landlord for any actual damages plus your attorney fees (ORS 90.255). Small-claims court is an option.
 
-            If you need free legal help, call the Oregon Law Center: 1-800-673-0506.
+            If you need free legal help, call the Oregon Law Center: 888-585-9638.
             """),
     },
     {

--- a/backend/scripts/generate_conversation/chat.py
+++ b/backend/scripts/generate_conversation/chat.py
@@ -17,7 +17,7 @@ from typing import Self
 BOT_INSTRUCTIONS = """Pretend you're a legal expert who giving advice about eviction notices in Oregon. 
 Please give shorter answers. 
 Please only ask one question at a time so that the user isn't confused. 
-If the user is being evicted for non-payment of rent and they are too poor to pay the rent and you have confirmed in various ways that the notice is valid and there is a valid court hearing date, then tell them to call Oregon Law Center at 5131234567. 
+If the user is being evicted for non-payment of rent and they are too poor to pay the rent and you have confirmed in various ways that the notice is valid and there is a valid court hearing date, then tell them to call Oregon Law Center at 888-585-9638. 
 Focus on finding technicalities that would legally prevent someone getting evicted, such as deficiencies in notice.
 Make sure to inclue a citation to the relevant law in your answer.
 

--- a/backend/tenantfirstaid/shared.py
+++ b/backend/tenantfirstaid/shared.py
@@ -17,7 +17,7 @@ DATA_DIR.mkdir(exist_ok=True)
 DEFAULT_INSTRUCTIONS = """Pretend you're a legal expert who giving advice about eviction notices in Oregon. 
 Please give shorter answers. 
 Please only ask one question at a time so that the user isn't confused. 
-If the user is being evicted for non-payment of rent and they are too poor to pay the rent and you have confirmed in various ways that the notice is valid and there is a valid court hearing date, then tell them to call Oregon Law Center at 5131234567. 
+If the user is being evicted for non-payment of rent and they are too poor to pay the rent and you have confirmed in various ways that the notice is valid and there is a valid court hearing date, then tell them to call Oregon Law Center at 888-585-9638. 
 Focus on finding technicalities that would legally prevent someone getting evicted, such as deficiencies in notice.
 Assume the user is on a month-to-month lease unless they specify otherwise.
 


### PR DESCRIPTION
Updates the Oregon Law Center contact phone number to 888-585-9638 in Python instruction files only, excluding CSV and JSONL data files as requested.

## Changes
- Updated main bot instruction files to use new phone number
- Excluded all data files (CSV, JSONL, JSON) from updates
- Total 3 Python files updated with new phone number

Closes #133

🤖 Generated with [Claude Code](https://claude.ai/code)