### PR TITLE
fix: keep location selection text unchanged during loading

### DIFF
--- a/frontend/src/pages/Chat/components/CitySelectField.tsx
+++ b/frontend/src/pages/Chat/components/CitySelectField.tsx
@@ -30,10 +30,12 @@ interface Props {
 
 export default function CitySelectField({ setMessages }: Props) {
   const [city, setCity] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
   const { initChat } = useMessages();
 
   const handleCityChange = async (key: string | null) => {
     setCity(key);
+    setIsLoading(true);
     const selectedCity =
       CitySelectOptions[key as keyof typeof CitySelectOptions];
     if (selectedCity && selectedCity.state) {
@@ -53,6 +55,8 @@ export default function CitySelectField({ setMessages }: Props) {
         ]);
       } catch (error) {
         console.error("Error initializing session:", error);
+      } finally {
+        setIsLoading(false);
       }
     }
   };
@@ -60,7 +64,7 @@ export default function CitySelectField({ setMessages }: Props) {
   return (
     <div className="flex flex-col gap-2">
       <p className="text-center text-[#888] mb-10">
-        {city
+        {city && !isLoading
           ? "Unfortunately we can only answer questions about tenant rights in Oregon right now."
           : "Welcome to Tenant First Aid! I can answer your questions about tenant rights in Oregon. To get started, what city are you located in?"}
       </p>


### PR DESCRIPTION
Fixes #134

This PR refines the previous fix for the location selection text flashing issue. Instead of showing different text during loading, the text now remains unchanged until the chat initialization is complete.

## Changes
- Added `isLoading` state to track chat initialization
- Updated text rendering logic to prevent flash during loading
- Text remains as welcome message during loading state
- Only shows different text after loading completes

## How It Works
1. Initial: Shows welcome message
2. User selects city: `isLoading` becomes true, text stays unchanged
3. After chat loads: `isLoading` becomes false, shows appropriate message

This eliminates the visual flash that occurred when text changed immediately upon city selection.

Generated with [Claude Code](https://claude.ai/code)