### PR TITLE
fix: show unfortunately text only for outside Oregon selection

### DIFF
--- a/frontend/src/pages/Chat/components/CitySelectField.tsx
+++ b/frontend/src/pages/Chat/components/CitySelectField.tsx
@@ -60,7 +60,7 @@ export default function CitySelectField({ setMessages }: Props) {
   return (
     <div className="flex flex-col gap-2">
       <p className="text-center text-[#888] mb-10">
-        {city
+        {city === "other"
           ? "Unfortunately we can only answer questions about tenant rights in Oregon right now."
           : "Welcome to Tenant First Aid! I can answer your questions about tenant rights in Oregon. To get started, what city are you located in?"}
       </p>


### PR DESCRIPTION
Fixes #134

This PR fixes the location selection text flashing issue by ensuring that only selections outside of Oregon show the "Unfortunately..." message immediately, while Oregon cities maintain the welcome message during loading.

## Changes
- Updated text display logic from `{city ?` to `{city === "other" ?`
- Oregon cities now keep welcome message during loading (no flash)
- Outside Oregon selection shows "Unfortunately..." text immediately

## How It Works
1. **No selection/Oregon cities**: Shows welcome message
2. **Outside Oregon selection**: Shows "Unfortunately..." message immediately
3. **No text flashing**: Oregon cities maintain consistent text during loading

Generated with [Claude Code](https://claude.ai/code)