### PR TITLE
Enhancement: Implement DM Sans as main font

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap");
 @import "tailwindcss";
 
 @layer base {
@@ -10,8 +11,15 @@
 body {
   margin: 0;
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-    Cantarell, sans-serif;
+    "DM Sans",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    sans-serif;
   color: #222829;
   line-height: 1.6;
 }


### PR DESCRIPTION
This PR is mainly for font implementation. The clip below shows "DM Sans" as the main font, as suggested from our Figma boards.

With DM Sans:

https://github.com/user-attachments/assets/af797143-2e89-413e-b023-ed327f372be2

Before:

https://github.com/user-attachments/assets/9933f0b6-84c9-423e-92e1-91d446e74f54
