### PR TITLE
check on push to main branch and releases

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+  push:
+    branches:
+      - main
+      - 'releases/*'
+
 jobs:
   backend-test:
     # skip this check for closed PRs that are not merged

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,7 +2,7 @@ name: PR Checks
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
   push:
     branches:
@@ -11,8 +11,6 @@ on:
 
 jobs:
   backend-test:
-    # skip this check for closed PRs that are not merged
-    if: ${{ github.event.action != 'closed' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -51,8 +49,6 @@ jobs:
         run: uv run pytest -v -s
 
   frontend-build:
-    # skip this check for closed PRs that are not merged
-    if: ${{ github.event.action != 'closed' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Merging a PR results in a push, but a push does not always imply a PR.  We want to know whether `main` is clean, regardless of how a change was made.