### PR TITLE
fix timeout for Claude job in workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,7 @@ jobs:
   claude:
     if: contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
@@ -44,5 +45,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-           --timeout-minutes 15
            --allowTools Read,Edit,Write,WebFetch


### PR DESCRIPTION
Fix syntax for Claude job
Increased the timeout for the Claude job from 15 to 30 minutes.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Infrastructure
- [ ] Maintenance

## Description

1. fixing the configuration for Claude job timeout
2. increasing the timeout to 30 minutes

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note on the devices and browsers this has been tested on, as well as any relevant images for UI changes._


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: infrastructure/automation code
- [ ] I need help with writing tests

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?

1. test with @ mention in issue comments and PRs