### PR TITLE
Patching React and React-DOM packages from Dec 11 CVEs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,8 +11,8 @@
         "@tailwindcss/vite": "^4.1.6",
         "@tanstack/react-query": "^5.77.2",
         "dompurify": "^3.3.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
         "react-router-dom": "^7.5.3",
         "tailwindcss": "^4.1.6"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,8 @@
     "@tailwindcss/vite": "^4.1.6",
     "@tanstack/react-query": "^5.77.2",
     "dompurify": "^3.3.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "react-router-dom": "^7.5.3",
     "tailwindcss": "^4.1.6"
   },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Infrastructure
- [x] Maintenance

## Description

This PR updates the React and React-DOM packages to address additional vulnerabilities identified on Dec. 11, 2025 after the previous score 10 CVE (see https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components for more information).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note on the devices and browsers this has been tested on, as well as any relevant images for UI changes._


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Patching vulnerable packages
- [ ] I need help with writing tests

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?
