### PR TITLE
[Bug fix] - Updated hover effects for hovering over links in chat

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -92,7 +92,7 @@ a {
 
 .message-bubble a,
 .generated-letter a {
-  @apply inline text-blue-link transition-colors hover:bg-blue-dark rounded;
+  @apply inline text-blue-link transition-colors hover:text-blue-dark rounded;
 }
 
 select {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Infrastructure
- [ ] Maintenance

## Description

This PR is a simple fix for hover effects over citations in chat (see clip below). It makes the hover effects more subtle without obscuring the link itself.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #251
- Closes #251

## QA Instructions, Screenshots, Recordings

https://github.com/user-attachments/assets/0d4d286a-2e8c-45aa-af19-cda92c285431

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?
