### PR TITLE
Fix evaluation setup docs and polars compat

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -628,9 +628,7 @@ The application uses environment-based secrets management:
 
 - `FLASK_SECRET_KEY` - Session encryption key
 - `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS_FILE` - Path to GCP service account JSON
-- `GEMINI_RAG_CORPUS` - Vertex AI RAG corpus identifier
-- `GEMINI_RAG_CORPUS_[CITY]` - Vertex AI RAG corpus identifier for a specific location (Optional)
-- `OPENAI_API_KEY` - OpenAI API key (used by data ingestion scripts)
+- `VERTEX_AI_DATASTORE` - Vertex AI Search data store ID
 
 **Security Measures:**
 

--- a/backend/scripts/EVALUATION.md
+++ b/backend/scripts/EVALUATION.md
@@ -24,7 +24,7 @@ Tenant First Aid uses LangSmith for automated quality evaluation of legal advice
 
 ```bash
 cd backend
-uv add langchain-google-vertexai
+uv add --group dev langchain-google-vertexai
 ```
 
 2. Create the LangSmith dataset from existing test scenarios:
@@ -47,7 +47,7 @@ uv run python scripts/run_langsmith_evaluation.py
 Run a specific experiment:
 
 ```bash
-uv run scripts/run_langsmith_evaluation.py \
+uv run python scripts/run_langsmith_evaluation.py \
   --dataset "tenant-legal-qa-scenarios" \
   --experiment "my-experiment" \
   --num-repetitions 1
@@ -153,7 +153,7 @@ https://smith.langchain.com/
 1. **Make code changes** to improve citation accuracy
 2. **Run evaluation locally**:
    ```bash
-   uv run python scripts/run_langsmith_evaluation.py --num-samples 10 --experiment "improve-citations"
+   uv run python scripts/run_langsmith_evaluation.py --experiment "improve-citations"
    ```
 3. **View results** in LangSmith dashboard
 4. **Compare** with baseline experiment

--- a/backend/scripts/EVALUATION.md
+++ b/backend/scripts/EVALUATION.md
@@ -20,10 +20,16 @@ Tenant First Aid uses LangSmith for automated quality evaluation of legal advice
 
 ### One-Time Setup
 
-Create the LangSmith dataset from existing test scenarios:
+1. Install the evaluator dependency. The chatbot uses `langchain-google-genai`, but the LLM-as-judge evaluators use `init_chat_model()` which resolves Gemini models to `ChatVertexAI` under the hood:
 
 ```bash
 cd backend
+uv add langchain-google-vertexai
+```
+
+2. Create the LangSmith dataset from existing test scenarios:
+
+```bash
 uv run python scripts/create_langsmith_dataset.py
 ```
 
@@ -35,13 +41,7 @@ Run evaluation on the full dataset:
 
 ```bash
 cd backend
-uv run scripts/run_langsmith_evaluation.py
-```
-
-Run evaluation on a subset (faster for development):
-
-```bash
-uv run scripts/run_langsmith_evaluation.py --num-samples 4
+uv run python scripts/run_langsmith_evaluation.py
 ```
 
 Run a specific experiment:

--- a/backend/scripts/EVALUATION.md
+++ b/backend/scripts/EVALUATION.md
@@ -188,7 +188,7 @@ LLM-as-judge evaluators can have biases. Review specific examples in LangSmith d
 
 ### Evaluation too slow
 - Reduce `max_concurrency` in `run_langsmith_evaluation.py`
-- Use `--num-samples` to evaluate a subset
+- Reduce the dataset size in LangSmith to evaluate a subset
 - Consider running full evaluation only before releases
 
 ### LANGSMITH_API_KEY not set

--- a/backend/scripts/create_langsmith_dataset.py
+++ b/backend/scripts/create_langsmith_dataset.py
@@ -71,7 +71,7 @@ def create_langsmith_dataset(
         df = pd.read_csv(csv_path, encoding="cp1252", n_rows=limit_examples)
 
     # replace all empty "city" values with "null" string
-    df["city"] = df["city"].fill_null("null")
+    df = df.with_columns(pd.col("city").fill_null("null"))
 
     # Convert each row to LangSmith example.
     for idx, row in enumerate(df.rows(named=True)):


### PR DESCRIPTION
Add missing langchain-google-vertexai dep to eval setup instructions (the LLM-as-judge evaluators need it even though the chatbot doesn't), remove the non-existent --num-samples CLI flag from examples, fix polars DataFrame column assignment that broke in newer versions, and clean up stale OpenAI/corpus references in Architecture.md.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Infrastructure
- [ ] Maintenance