### PR TITLE
Add vertex_ai_search script for independent RAG debugging

### DIFF
--- a/backend/scripts/vertex_ai_list_datastores.py
+++ b/backend/scripts/vertex_ai_list_datastores.py
@@ -7,8 +7,9 @@ To run:
   % uv run simple_langchain_example.py
 """
 
-from google.api_core.client_options import ClientOptions
 from google.cloud import discoveryengine
+
+from tenantfirstaid.google_auth import discoveryengine_client_options
 
 project_id = "tenantfirstaid"  # Replace with your GCP project ID
 location = "global"  # Values: "global"
@@ -18,16 +19,9 @@ def list_data_stores(
     project_id: str,
     location: str,
 ):  # -> discoveryengine.ListDataStoresResponse:
-    #  For more information, refer to:
-    # https://cloud.google.com/generative-ai-app-builder/docs/locations#specify_a_multi-region_for_your_data_store
-    client_options = (
-        ClientOptions(api_endpoint=f"{location}-discoveryengine.googleapis.com")
-        if location != "global"
-        else None
+    client = discoveryengine.DataStoreServiceClient(
+        client_options=discoveryengine_client_options(location)
     )
-
-    # Create a client
-    client = discoveryengine.DataStoreServiceClient(client_options=client_options)
 
     request = discoveryengine.ListDataStoresRequest(
         # The full resource name of the data store

--- a/backend/scripts/vertex_ai_list_datastores.py
+++ b/backend/scripts/vertex_ai_list_datastores.py
@@ -1,10 +1,7 @@
-"""
-Dump out info on project datastores in Google Workspace
-
-Note: does not require credentials or authentication(?)
+"""Dump info on Vertex AI Search datastores for a GCP project.
 
 To run:
-  % uv run simple_langchain_example.py
+  uv run python -m scripts.vertex_ai_list_datastores
 """
 
 from google.cloud import discoveryengine
@@ -15,10 +12,7 @@ project_id = "tenantfirstaid"  # Replace with your GCP project ID
 location = "global"  # Values: "global"
 
 
-def list_data_stores(
-    project_id: str,
-    location: str,
-):  # -> discoveryengine.ListDataStoresResponse:
+def list_data_stores(project_id: str, location: str) -> None:
     client = discoveryengine.DataStoreServiceClient(
         client_options=discoveryengine_client_options(location)
     )

--- a/backend/scripts/vertex_ai_search.py
+++ b/backend/scripts/vertex_ai_search.py
@@ -1,0 +1,393 @@
+"""Query the Vertex AI Search datastore directly, bypassing LangChain/LangGraph.
+
+Useful for debugging retrieval quality independently of the agent framework:
+what passages does the datastore actually return for a given query and filter?
+
+Usage:
+    uv run python -m scripts.vertex_ai_search "security deposit interest" --state or
+    uv run python -m scripts.vertex_ai_search "ORS 90.155 notice delivery" --state or --city portland
+    uv run python -m scripts.vertex_ai_search "nonpayment notice timing" --state or --max-results 10
+    uv run python -m scripts.vertex_ai_search "ORS 90.427" --state or --raw
+
+    # Sweep extraction params to find diminishing returns:
+    uv run python -m scripts.vertex_ai_search shmoo \\
+        "72 hour nonpayment notice week-to-week ORS 90.394" \\
+        --target "fifth day" --state or
+"""
+
+import argparse
+import json
+import textwrap
+from typing import List, Optional
+
+from google.api_core.client_options import ClientOptions
+from google.cloud import discoveryengine_v1beta as discoveryengine
+from google.cloud.discoveryengine_v1beta.services.search_service.pagers import (
+    SearchPager,
+)
+
+from tenantfirstaid.constants import SINGLETON, DatastoreKey
+from tenantfirstaid.google_auth import load_gcp_credentials
+from tenantfirstaid.langchain_tools import _filter_builder, _repair_mojibake
+from tenantfirstaid.location import OregonCity, UsaState
+
+
+def search(
+    query: str,
+    *,
+    state: UsaState,
+    city: Optional[OregonCity] = None,
+    max_results: int = 5,
+    max_extractive_answer_count: int = 5,
+    max_extractive_segment_count: int = 3,
+    spell_correction: int = 1,
+    datastore_override: Optional[str] = None,
+) -> SearchPager:
+    """Run a search against the Vertex AI Search datastore and return the raw response."""
+    assert SINGLETON.GOOGLE_APPLICATION_CREDENTIALS is not None
+    credentials = load_gcp_credentials(SINGLETON.GOOGLE_APPLICATION_CREDENTIALS)
+
+    location = SINGLETON.GOOGLE_CLOUD_LOCATION or "global"
+    client_options = (
+        ClientOptions(api_endpoint=f"{location}-discoveryengine.googleapis.com")
+        if location != "global"
+        else None
+    )
+
+    client = discoveryengine.SearchServiceClient(
+        credentials=credentials,
+        client_options=client_options,
+    )
+
+    datastore = datastore_override or SINGLETON.VERTEX_AI_DATASTORES[DatastoreKey.LAWS]
+    serving_config = (
+        f"projects/{SINGLETON.GOOGLE_CLOUD_PROJECT}"
+        f"/locations/{location}"
+        f"/collections/default_collection"
+        f"/dataStores/{datastore}"
+        f"/servingConfigs/default_serving_config"
+    )
+
+    content_search_spec = discoveryengine.SearchRequest.ContentSearchSpec(
+        extractive_content_spec=discoveryengine.SearchRequest.ContentSearchSpec.ExtractiveContentSpec(
+            max_extractive_answer_count=max_extractive_answer_count,
+            max_extractive_segment_count=max_extractive_segment_count,
+        ),
+        snippet_spec=discoveryengine.SearchRequest.ContentSearchSpec.SnippetSpec(
+            return_snippet=True,
+        ),
+    )
+
+    spell_correction_spec = discoveryengine.SearchRequest.SpellCorrectionSpec(
+        mode=spell_correction,
+    )
+
+    request = discoveryengine.SearchRequest(
+        serving_config=serving_config,
+        query=query,
+        page_size=max_results,
+        filter=_filter_builder(state, city),
+        content_search_spec=content_search_spec,
+        spell_correction_spec=spell_correction_spec,
+    )
+
+    return client.search(request)
+
+
+def _collect_passages(response: SearchPager) -> List[dict]:
+    """Collect all extractive answers and segments from a search response."""
+    passages = []
+    for result in response.results:
+        doc = result.document
+        struct = doc.derived_struct_data
+        if not struct:
+            continue
+        doc_id = doc.id or "(no id)"
+        for answer in struct.get("extractive_answers", []):
+            content = _repair_mojibake(answer.get("content", ""))
+            passages.append({"doc_id": doc_id, "type": "answer", "content": content})
+        for segment in struct.get("extractive_segments", []):
+            content = _repair_mojibake(segment.get("content", ""))
+            passages.append({"doc_id": doc_id, "type": "segment", "content": content})
+    return passages
+
+
+def _print_results(
+    response: SearchPager,
+    *,
+    raw: bool = False,
+    width: int = 100,
+) -> None:
+    """Pretty-print search results to stdout."""
+    if hasattr(response, "corrected_query") and response.corrected_query:
+        print(f"Spell-corrected query: {response.corrected_query}\n")
+
+    count = 0
+    for i, result in enumerate(response.results, 1):
+        count = i
+        doc = result.document
+        struct = doc.derived_struct_data
+
+        doc_id = doc.id or "(no id)"
+        title = struct.get("title", "(no title)") if struct else "(no struct_data)"
+
+        print(f"── Result {i}: {title} ──")
+        print(f"  doc_id: {doc_id}")
+
+        if struct:
+            link = struct.get("link", "")
+            if link:
+                print(f"  link:   {link}")
+
+            for j, answer in enumerate(struct.get("extractive_answers", [])):
+                content = _repair_mojibake(answer.get("content", ""))
+                page = answer.get("pageNumber", "?")
+                wrapped = textwrap.fill(
+                    content,
+                    width=width,
+                    initial_indent="    ",
+                    subsequent_indent="    ",
+                )
+                print(f"  extractive_answer[{j}] (page {page}):")
+                print(wrapped)
+
+            for j, segment in enumerate(struct.get("extractive_segments", [])):
+                content = _repair_mojibake(segment.get("content", ""))
+                page = segment.get("pageNumber", "?")
+                wrapped = textwrap.fill(
+                    content,
+                    width=width,
+                    initial_indent="    ",
+                    subsequent_indent="    ",
+                )
+                print(f"  extractive_segment[{j}] (page {page}):")
+                print(wrapped)
+
+            for j, snippet in enumerate(struct.get("snippets", [])):
+                text = _repair_mojibake(snippet.get("snippet", ""))
+                wrapped = textwrap.fill(
+                    text,
+                    width=width,
+                    initial_indent="    ",
+                    subsequent_indent="    ",
+                )
+                print(f"  snippet[{j}]:")
+                print(wrapped)
+
+        if raw:
+            print("  raw_struct_data:")
+            print(
+                textwrap.indent(
+                    json.dumps(
+                        dict(struct) if struct else {},
+                        indent=2,
+                        default=str,
+                    ),
+                    "    ",
+                )
+            )
+
+        print()
+
+    if count == 0:
+        print("No results found.")
+    else:
+        print(f"({count} results)")
+
+
+def _shmoo(
+    query: str,
+    *,
+    state: UsaState,
+    city: Optional[OregonCity] = None,
+    max_results: int = 5,
+    targets: List[str],
+    max_answer_sweep: int = 5,
+    max_segment_sweep: int = 10,
+    datastore_override: Optional[str] = None,
+) -> None:
+    """Sweep extractive answer and segment counts, reporting where targets appear."""
+    targets_lower = [t.lower() for t in targets]
+
+    def _check(passages: List[dict]) -> List[str]:
+        """Return list of (doc_id, type) pairs where any target matched."""
+        hits = []
+        for p in passages:
+            content_lower = p["content"].lower()
+            if any(t in content_lower for t in targets_lower):
+                hits.append(f"{p['doc_id']}:{p['type']}")
+        return hits
+
+    filter_str = _filter_builder(state, city)
+    print(f"Query:   {query}")
+    print(f"Filter:  {filter_str}")
+    print(f"Targets: {targets}")
+    print(f"Docs:    {max_results}")
+    print()
+
+    # Sweep extractive answers (segments fixed at 1).
+    print(f"{'answers':>8}  {'hits':>4}  where")
+    print(f"{'-------':>8}  {'----':>4}  -----")
+    prev_hit_count = -1
+    for n in range(1, max_answer_sweep + 1):
+        response = search(
+            query,
+            state=state,
+            city=city,
+            max_results=max_results,
+            max_extractive_answer_count=n,
+            max_extractive_segment_count=1,
+            datastore_override=datastore_override,
+        )
+        passages = _collect_passages(response)
+        hits = _check(passages)
+        marker = "  <-- new" if len(hits) > prev_hit_count else ""
+        locations = ", ".join(hits) if hits else "(none)"
+        print(f"{n:>8}  {len(hits):>4}  {locations}{marker}")
+        prev_hit_count = len(hits)
+
+    print()
+
+    # Sweep extractive segments (answers fixed at 1).
+    print(f"{'segments':>8}  {'hits':>4}  where")
+    print(f"{'--------':>8}  {'----':>4}  -----")
+    prev_hit_count = -1
+    for n in range(1, max_segment_sweep + 1):
+        response = search(
+            query,
+            state=state,
+            city=city,
+            max_results=max_results,
+            max_extractive_answer_count=1,
+            max_extractive_segment_count=n,
+        )
+        passages = _collect_passages(response)
+        hits = _check(passages)
+        marker = "  <-- new" if len(hits) > prev_hit_count else ""
+        locations = ", ".join(hits) if hits else "(none)"
+        print(f"{n:>8}  {len(hits):>4}  {locations}{marker}")
+        prev_hit_count = len(hits)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Query Vertex AI Search directly, bypassing LangChain",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    # Shared arguments.
+    shared = argparse.ArgumentParser(add_help=False)
+    shared.add_argument(
+        "--state", type=str, default="or", help="State filter (e.g. 'or')"
+    )
+    shared.add_argument(
+        "--city", type=str, default=None, help="City filter (e.g. 'portland', 'eugene')"
+    )
+    shared.add_argument(
+        "--max-results", type=int, default=5, help="Maximum number of documents"
+    )
+    shared.add_argument(
+        "--datastore",
+        type=str,
+        default=None,
+        metavar="DATASTORE_ID",
+        help="Override the VERTEX_AI_DATASTORE from the environment (e.g. to test an alternate corpus)",
+    )
+
+    # Default: single search.
+    search_parser = subparsers.add_parser(
+        "search", parents=[shared], help="Run a single search query"
+    )
+    search_parser.add_argument("query", help="Search query text")
+    search_parser.add_argument(
+        "--answers", type=int, default=5, help="Extractive answers per document"
+    )
+    search_parser.add_argument(
+        "--segments", type=int, default=3, help="Extractive segments per document"
+    )
+    search_parser.add_argument(
+        "--raw", action="store_true", help="Print raw struct_data JSON"
+    )
+    search_parser.add_argument(
+        "--width", type=int, default=100, help="Text wrapping width"
+    )
+
+    # Shmoo: sweep extraction params.
+    shmoo_parser = subparsers.add_parser(
+        "shmoo",
+        parents=[shared],
+        help="Sweep extraction params to find diminishing returns",
+    )
+    shmoo_parser.add_argument("query", help="Search query text")
+    shmoo_parser.add_argument(
+        "--target",
+        action="append",
+        required=True,
+        dest="targets",
+        help="Substring to look for in results (repeatable)",
+    )
+    shmoo_parser.add_argument(
+        "--max-answer-sweep",
+        type=int,
+        default=5,
+        help="Max extractive answer count to sweep (API caps at 5)",
+    )
+    shmoo_parser.add_argument(
+        "--max-segment-sweep",
+        type=int,
+        default=10,
+        help="Max extractive segment count to sweep",
+    )
+
+    args = parser.parse_args()
+
+    # Support bare invocation (no subcommand) for backwards compatibility.
+    if args.command is None:
+        # Re-parse as if "search" was specified.
+        parser.parse_args(["search", "--help"])
+        return
+
+    state = UsaState.from_maybe_str(args.state)
+    city = OregonCity.from_maybe_str(args.city) if args.city else None
+
+    datastore = args.datastore or SINGLETON.VERTEX_AI_DATASTORES[DatastoreKey.LAWS]
+
+    if args.command == "shmoo":
+        _shmoo(
+            args.query,
+            state=state,
+            city=city,
+            max_results=args.max_results,
+            targets=args.targets,
+            max_answer_sweep=args.max_answer_sweep,
+            max_segment_sweep=args.max_segment_sweep,
+            datastore_override=args.datastore,
+        )
+        return
+
+    # "search" command.
+    filter_str = _filter_builder(state, city)
+    print(f"Query:     {args.query}")
+    print(f"Filter:    {filter_str}")
+    print(f"Datastore: {datastore}")
+    print(f"Docs:      {args.max_results}")
+    print(f"Answers:   {args.answers}")
+    print(f"Segments:  {args.segments}")
+    print()
+
+    response = search(
+        args.query,
+        state=state,
+        city=city,
+        max_results=args.max_results,
+        max_extractive_answer_count=args.answers,
+        max_extractive_segment_count=args.segments,
+        datastore_override=args.datastore,
+    )
+
+    _print_results(response, raw=args.raw, width=args.width)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/vertex_ai_search.py
+++ b/backend/scripts/vertex_ai_search.py
@@ -18,7 +18,7 @@ Usage:
 import argparse
 import json
 import textwrap
-from typing import List, Optional
+from typing import TypedDict
 
 from google.api_core.client_options import ClientOptions
 from google.cloud import discoveryengine_v1beta as discoveryengine
@@ -28,20 +28,26 @@ from google.cloud.discoveryengine_v1beta.services.search_service.pagers import (
 
 from tenantfirstaid.constants import SINGLETON, DatastoreKey
 from tenantfirstaid.google_auth import load_gcp_credentials
-from tenantfirstaid.langchain_tools import _filter_builder, _repair_mojibake
+from tenantfirstaid.langchain_tools import filter_builder, repair_mojibake
 from tenantfirstaid.location import OregonCity, UsaState
+
+
+class Passage(TypedDict):
+    doc_id: str
+    type: str
+    content: str
 
 
 def search(
     query: str,
     *,
     state: UsaState,
-    city: Optional[OregonCity] = None,
+    city: OregonCity | None = None,
     max_results: int = 5,
     max_extractive_answer_count: int = 5,
     max_extractive_segment_count: int = 3,
     spell_correction: int = 1,
-    datastore_override: Optional[str] = None,
+    datastore_override: str | None = None,
 ) -> SearchPager:
     """Run a search against the Vertex AI Search datastore and return the raw response."""
     credentials = load_gcp_credentials(SINGLETON.GOOGLE_APPLICATION_CREDENTIALS)
@@ -85,7 +91,7 @@ def search(
         serving_config=serving_config,
         query=query,
         page_size=max_results,
-        filter=_filter_builder(state, city),
+        filter=filter_builder(state, city),
         content_search_spec=content_search_spec,
         spell_correction_spec=spell_correction_spec,
     )
@@ -93,9 +99,9 @@ def search(
     return client.search(request)
 
 
-def _collect_passages(response: SearchPager) -> List[dict]:
+def _collect_passages(response: SearchPager) -> list[Passage]:
     """Collect all extractive answers and segments from a search response."""
-    passages = []
+    passages: list[Passage] = []
     for result in response.results:
         doc = result.document
         struct = doc.derived_struct_data
@@ -103,10 +109,10 @@ def _collect_passages(response: SearchPager) -> List[dict]:
             continue
         doc_id = doc.id or "(no id)"
         for answer in struct.get("extractive_answers", []):
-            content = _repair_mojibake(answer.get("content", ""))
+            content = repair_mojibake(answer.get("content", ""))
             passages.append({"doc_id": doc_id, "type": "answer", "content": content})
         for segment in struct.get("extractive_segments", []):
-            content = _repair_mojibake(segment.get("content", ""))
+            content = repair_mojibake(segment.get("content", ""))
             passages.append({"doc_id": doc_id, "type": "segment", "content": content})
     return passages
 
@@ -139,7 +145,7 @@ def _print_results(
                 print(f"  link:   {link}")
 
             for j, answer in enumerate(struct.get("extractive_answers", [])):
-                content = _repair_mojibake(answer.get("content", ""))
+                content = repair_mojibake(answer.get("content", ""))
                 page = answer.get("pageNumber", "?")
                 wrapped = textwrap.fill(
                     content,
@@ -151,7 +157,7 @@ def _print_results(
                 print(wrapped)
 
             for j, segment in enumerate(struct.get("extractive_segments", [])):
-                content = _repair_mojibake(segment.get("content", ""))
+                content = repair_mojibake(segment.get("content", ""))
                 page = segment.get("pageNumber", "?")
                 wrapped = textwrap.fill(
                     content,
@@ -163,7 +169,7 @@ def _print_results(
                 print(wrapped)
 
             for j, snippet in enumerate(struct.get("snippets", [])):
-                text = _repair_mojibake(snippet.get("snippet", ""))
+                text = repair_mojibake(snippet.get("snippet", ""))
                 wrapped = textwrap.fill(
                     text,
                     width=width,
@@ -198,17 +204,17 @@ def _shmoo(
     query: str,
     *,
     state: UsaState,
-    city: Optional[OregonCity] = None,
+    city: OregonCity | None = None,
     max_results: int = 5,
-    targets: List[str],
+    targets: list[str],
     max_answer_sweep: int = 5,
     max_segment_sweep: int = 10,
-    datastore_override: Optional[str] = None,
+    datastore_override: str | None = None,
 ) -> None:
     """Sweep extractive answer and segment counts, reporting where targets appear."""
     targets_lower = [t.lower() for t in targets]
 
-    def _check(passages: List[dict]) -> List[str]:
+    def _check(passages: list[Passage]) -> list[str]:
         """Return list of strings of the form "doc_id:type" where any target matched."""
         hits = []
         for p in passages:
@@ -217,12 +223,14 @@ def _shmoo(
                 hits.append(f"{p['doc_id']}:{p['type']}")
         return hits
 
-    filter_str = _filter_builder(state, city)
     print(f"Query:   {query}")
-    print(f"Filter:  {filter_str}")
+    print(f"Filter:  {filter_builder(state, city)}")
     print(f"Targets: {targets}")
     print(f"Docs:    {max_results}")
     print()
+
+    # Each axis is swept independently with the other fixed at 1, avoiding O(m×n)
+    # API calls. The independent maxima are sufficient for tuning each parameter.
 
     # Sweep extractive answers (segments fixed at 1).
     print(f"{'answers':>8}  {'hits':>4}  where")
@@ -343,7 +351,8 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command is None:
-        parser.parse_args(["search", "--help"])
+        parser.print_help()
+        raise SystemExit(1)
 
     state = UsaState.from_maybe_str(args.state)
     city = OregonCity.from_maybe_str(args.city) if args.city else None
@@ -366,9 +375,8 @@ def main() -> None:
         return
 
     # "search" command.
-    filter_str = _filter_builder(state, city)
     print(f"Query:     {args.query}")
-    print(f"Filter:    {filter_str}")
+    print(f"Filter:    {filter_builder(state, city)}")
     print(f"Datastore: {datastore}")
     print(f"Docs:      {args.max_results}")
     print(f"Answers:   {args.answers}")

--- a/backend/scripts/vertex_ai_search.py
+++ b/backend/scripts/vertex_ai_search.py
@@ -18,7 +18,7 @@ Usage:
 import argparse
 import json
 import textwrap
-from typing import TypedDict
+from dataclasses import dataclass, field
 
 from google.api_core.client_options import ClientOptions
 from google.cloud import discoveryengine_v1beta as discoveryengine
@@ -29,17 +29,96 @@ from tenantfirstaid.langchain_tools import filter_builder, repair_mojibake
 from tenantfirstaid.location import OregonCity, UsaState
 
 SearchResult = discoveryengine.SearchResponse.SearchResult
+SpellMode = discoveryengine.SearchRequest.SpellCorrectionSpec.Mode
 
 
-class Passage(TypedDict):
+@dataclass
+class Passage:
     doc_id: str
     type: str
     content: str
 
 
-class SearchResults(TypedDict):
+@dataclass
+class SearchResults:
     corrected_query: str
-    results: list[SearchResult]
+    results: list[SearchResult] = field(default_factory=list)
+
+    def passages(self) -> list[Passage]:
+        """Collect all extractive answers and segments from this response."""
+        out: list[Passage] = []
+        for result in self.results:
+            doc = result.document
+            struct = doc.derived_struct_data
+            if not struct:
+                continue
+            doc_id = doc.id or "(no id)"
+            for answer in struct.get("extractive_answers", []):
+                content = repair_mojibake(answer.get("content", ""))
+                out.append(Passage(doc_id=doc_id, type="answer", content=content))
+            for segment in struct.get("extractive_segments", []):
+                content = repair_mojibake(segment.get("content", ""))
+                out.append(Passage(doc_id=doc_id, type="segment", content=content))
+        return out
+
+    def print(self, *, raw: bool = False, width: int = 100) -> None:
+        """Pretty-print these search results to stdout."""
+        if self.corrected_query:
+            print(f"Spell-corrected query: {self.corrected_query}\n")
+
+        def _print_passages(key: str, items: list) -> None:
+            for j, item in enumerate(items):
+                content = repair_mojibake(item.get("content", ""))
+                page = item.get("pageNumber", "?")
+                print(f"  {key}[{j}] (page {page}):")
+                print(_wrap(content, width=width))
+
+        for i, result in enumerate(self.results, 1):
+            doc = result.document
+            struct = doc.derived_struct_data
+
+            doc_id = doc.id or "(no id)"
+            title = struct.get("title", "(no title)") if struct else "(no struct_data)"
+
+            print(f"── Result {i}: {title} ──")
+            print(f"  doc_id: {doc_id}")
+
+            if struct:
+                link = struct.get("link", "")
+                if link:
+                    print(f"  link:   {link}")
+
+                _print_passages(
+                    "extractive_answer", struct.get("extractive_answers", [])
+                )
+                _print_passages(
+                    "extractive_segment", struct.get("extractive_segments", [])
+                )
+
+                for j, snippet in enumerate(struct.get("snippets", [])):
+                    text = repair_mojibake(snippet.get("snippet", ""))
+                    print(f"  snippet[{j}]:")
+                    print(_wrap(text, width=width))
+
+            if raw:
+                print("  raw_struct_data:")
+                print(
+                    textwrap.indent(
+                        json.dumps(
+                            dict(struct) if struct else {},
+                            indent=2,
+                            default=str,
+                        ),
+                        "    ",
+                    )
+                )
+
+            print()
+
+        if not self.results:
+            print("No results found.")
+        else:
+            print(f"({len(self.results)} results)")
 
 
 def search(
@@ -50,7 +129,7 @@ def search(
     max_results: int = 5,
     max_extractive_answer_count: int = 5,
     max_extractive_segment_count: int = 3,
-    spell_correction: discoveryengine.SearchRequest.SpellCorrectionSpec.Mode = discoveryengine.SearchRequest.SpellCorrectionSpec.Mode.AUTO,
+    spell_correction: SpellMode = SpellMode.AUTO,
     datastore_override: str | None = None,
 ) -> SearchResults:
     """Run a search against the Vertex AI Search datastore and return results."""
@@ -108,105 +187,13 @@ def search(
     )
 
 
-def _collect_passages(response: SearchResults) -> list[Passage]:
-    """Collect all extractive answers and segments from a search response."""
-    passages: list[Passage] = []
-    for result in response["results"]:
-        doc = result.document
-        struct = doc.derived_struct_data
-        if not struct:
-            continue
-        doc_id = doc.id or "(no id)"
-        for answer in struct.get("extractive_answers", []):
-            content = repair_mojibake(answer.get("content", ""))
-            passages.append({"doc_id": doc_id, "type": "answer", "content": content})
-        for segment in struct.get("extractive_segments", []):
-            content = repair_mojibake(segment.get("content", ""))
-            passages.append({"doc_id": doc_id, "type": "segment", "content": content})
-    return passages
-
-
-def _print_results(
-    response: SearchResults,
-    *,
-    raw: bool = False,
-    width: int = 100,
-) -> None:
-    """Pretty-print search results to stdout."""
-    if response["corrected_query"]:
-        print(f"Spell-corrected query: {response['corrected_query']}\n")
-
-    count = 0
-    for i, result in enumerate(response["results"], 1):
-        count = i
-        doc = result.document
-        struct = doc.derived_struct_data
-
-        doc_id = doc.id or "(no id)"
-        title = struct.get("title", "(no title)") if struct else "(no struct_data)"
-
-        print(f"── Result {i}: {title} ──")
-        print(f"  doc_id: {doc_id}")
-
-        if struct:
-            link = struct.get("link", "")
-            if link:
-                print(f"  link:   {link}")
-
-            for j, answer in enumerate(struct.get("extractive_answers", [])):
-                content = repair_mojibake(answer.get("content", ""))
-                page = answer.get("pageNumber", "?")
-                wrapped = textwrap.fill(
-                    content,
-                    width=width,
-                    initial_indent="    ",
-                    subsequent_indent="    ",
-                )
-                print(f"  extractive_answer[{j}] (page {page}):")
-                print(wrapped)
-
-            for j, segment in enumerate(struct.get("extractive_segments", [])):
-                content = repair_mojibake(segment.get("content", ""))
-                page = segment.get("pageNumber", "?")
-                wrapped = textwrap.fill(
-                    content,
-                    width=width,
-                    initial_indent="    ",
-                    subsequent_indent="    ",
-                )
-                print(f"  extractive_segment[{j}] (page {page}):")
-                print(wrapped)
-
-            for j, snippet in enumerate(struct.get("snippets", [])):
-                text = repair_mojibake(snippet.get("snippet", ""))
-                wrapped = textwrap.fill(
-                    text,
-                    width=width,
-                    initial_indent="    ",
-                    subsequent_indent="    ",
-                )
-                print(f"  snippet[{j}]:")
-                print(wrapped)
-
-        if raw:
-            print("  raw_struct_data:")
-            print(
-                textwrap.indent(
-                    json.dumps(
-                        dict(struct) if struct else {},
-                        indent=2,
-                        default=str,
-                    ),
-                    "    ",
-                )
-            )
-
-        print()
-
-    if count == 0:
-        print("No results found.")
-    else:
-        print(f"({count} results)")
+def _wrap(text: str, *, width: int) -> str:
+    return textwrap.fill(
+        text,
+        width=width,
+        initial_indent="    ",
+        subsequent_indent="    ",
+    )
 
 
 def _shmoo(
@@ -218,7 +205,7 @@ def _shmoo(
     targets: list[str],
     max_answer_sweep: int = 5,
     max_segment_sweep: int = 10,
-    datastore_override: str | None = None,
+    datastore: str,
 ) -> None:
     """Sweep extractive answer and segment counts, reporting where targets appear."""
     targets_lower = [t.lower() for t in targets]
@@ -228,17 +215,18 @@ def _shmoo(
         seen: set[str] = set()
         hits = []
         for p in passages:
-            key = f"{p['doc_id']}:{p['type']}"
-            content_lower = p["content"].lower()
+            key = f"{p.doc_id}:{p.type}"
+            content_lower = p.content.lower()
             if key not in seen and any(t in content_lower for t in targets_lower):
                 seen.add(key)
                 hits.append(key)
         return hits
 
-    print(f"Query:   {query}")
-    print(f"Filter:  {filter_builder(state, city)}")
-    print(f"Targets: {targets}")
-    print(f"Docs:    {max_results}")
+    print(f"Query:     {query}")
+    print(f"Filter:    {filter_builder(state, city)}")
+    print(f"Datastore: {datastore}")
+    print(f"Targets:   {targets}")
+    print(f"Docs:      {max_results}")
     print()
 
     # Each axis is swept independently with the other fixed at 1, avoiding O(m×n)
@@ -256,9 +244,9 @@ def _shmoo(
             max_results=max_results,
             max_extractive_answer_count=n,
             max_extractive_segment_count=1,
-            datastore_override=datastore_override,
+            datastore_override=datastore,
         )
-        passages = _collect_passages(response)
+        passages = response.passages()
         hits = _check(passages)
         marker = "  <-- new" if len(hits) > prev_hit_count else ""
         locations = ", ".join(hits) if hits else "(none)"
@@ -279,9 +267,9 @@ def _shmoo(
             max_results=max_results,
             max_extractive_answer_count=1,
             max_extractive_segment_count=n,
-            datastore_override=datastore_override,
+            datastore_override=datastore,
         )
-        passages = _collect_passages(response)
+        passages = response.passages()
         hits = _check(passages)
         marker = "  <-- new" if len(hits) > prev_hit_count else ""
         locations = ", ".join(hits) if hits else "(none)"
@@ -382,7 +370,7 @@ def main() -> None:
             targets=args.targets,
             max_answer_sweep=args.max_answer_sweep,
             max_segment_sweep=args.max_segment_sweep,
-            datastore_override=args.datastore,
+            datastore=datastore,
         )
         return
 
@@ -402,10 +390,10 @@ def main() -> None:
         max_results=args.max_results,
         max_extractive_answer_count=args.answers,
         max_extractive_segment_count=args.segments,
-        datastore_override=args.datastore,
+        datastore_override=datastore,
     )
 
-    _print_results(response, raw=args.raw, width=args.width)
+    response.print(raw=args.raw, width=args.width)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/vertex_ai_search.py
+++ b/backend/scripts/vertex_ai_search.py
@@ -4,10 +4,10 @@ Useful for debugging retrieval quality independently of the agent framework:
 what passages does the datastore actually return for a given query and filter?
 
 Usage:
-    uv run python -m scripts.vertex_ai_search "security deposit interest" --state or
-    uv run python -m scripts.vertex_ai_search "ORS 90.155 notice delivery" --state or --city portland
-    uv run python -m scripts.vertex_ai_search "nonpayment notice timing" --state or --max-results 10
-    uv run python -m scripts.vertex_ai_search "ORS 90.427" --state or --raw
+    uv run python -m scripts.vertex_ai_search search "security deposit interest" --state or
+    uv run python -m scripts.vertex_ai_search search "ORS 90.155 notice delivery" --state or --city portland
+    uv run python -m scripts.vertex_ai_search search "nonpayment notice timing" --state or --max-results 10
+    uv run python -m scripts.vertex_ai_search search "ORS 90.427" --state or --raw
 
     # Sweep extraction params to find diminishing returns:
     uv run python -m scripts.vertex_ai_search shmoo \\
@@ -44,7 +44,6 @@ def search(
     datastore_override: Optional[str] = None,
 ) -> SearchPager:
     """Run a search against the Vertex AI Search datastore and return the raw response."""
-    assert SINGLETON.GOOGLE_APPLICATION_CREDENTIALS is not None
     credentials = load_gcp_credentials(SINGLETON.GOOGLE_APPLICATION_CREDENTIALS)
 
     location = SINGLETON.GOOGLE_CLOUD_LOCATION or "global"
@@ -210,7 +209,7 @@ def _shmoo(
     targets_lower = [t.lower() for t in targets]
 
     def _check(passages: List[dict]) -> List[str]:
-        """Return list of (doc_id, type) pairs where any target matched."""
+        """Return list of strings of the form "doc_id:type" where any target matched."""
         hits = []
         for p in passages:
             content_lower = p["content"].lower()
@@ -260,6 +259,7 @@ def _shmoo(
             max_results=max_results,
             max_extractive_answer_count=1,
             max_extractive_segment_count=n,
+            datastore_override=datastore_override,
         )
         passages = _collect_passages(response)
         hits = _check(passages)
@@ -342,14 +342,13 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # Support bare invocation (no subcommand) for backwards compatibility.
     if args.command is None:
-        # Re-parse as if "search" was specified.
         parser.parse_args(["search", "--help"])
-        return
 
     state = UsaState.from_maybe_str(args.state)
     city = OregonCity.from_maybe_str(args.city) if args.city else None
+    if args.city and city is None:
+        print(f"Warning: unrecognized city '{args.city}', no city filter applied.")
 
     datastore = args.datastore or SINGLETON.VERTEX_AI_DATASTORES[DatastoreKey.LAWS]
 

--- a/backend/scripts/vertex_ai_search.py
+++ b/backend/scripts/vertex_ai_search.py
@@ -19,12 +19,12 @@ import argparse
 import json
 import textwrap
 from dataclasses import dataclass, field
+from typing import Literal
 
-from google.api_core.client_options import ClientOptions
 from google.cloud import discoveryengine_v1beta as discoveryengine
 
 from tenantfirstaid.constants import SINGLETON, DatastoreKey
-from tenantfirstaid.google_auth import load_gcp_credentials
+from tenantfirstaid.google_auth import discoveryengine_client_options, load_gcp_credentials
 from tenantfirstaid.langchain_tools import filter_builder, repair_mojibake
 from tenantfirstaid.location import OregonCity, UsaState
 
@@ -35,7 +35,7 @@ SpellMode = discoveryengine.SearchRequest.SpellCorrectionSpec.Mode
 @dataclass
 class Passage:
     doc_id: str
-    type: str
+    type: Literal["answer", "segment"]
     content: str
 
 
@@ -66,13 +66,6 @@ class SearchResults:
         if self.corrected_query:
             print(f"Spell-corrected query: {self.corrected_query}\n")
 
-        def _print_passages(key: str, items: list) -> None:
-            for j, item in enumerate(items):
-                content = repair_mojibake(item.get("content", ""))
-                page = item.get("pageNumber", "?")
-                print(f"  {key}[{j}] (page {page}):")
-                print(_wrap(content, width=width))
-
         for i, result in enumerate(self.results, 1):
             doc = result.document
             struct = doc.derived_struct_data
@@ -89,10 +82,10 @@ class SearchResults:
                     print(f"  link:   {link}")
 
                 _print_passages(
-                    "extractive_answer", struct.get("extractive_answers", [])
+                    "extractive_answer", struct.get("extractive_answers", []), width=width
                 )
                 _print_passages(
-                    "extractive_segment", struct.get("extractive_segments", [])
+                    "extractive_segment", struct.get("extractive_segments", []), width=width
                 )
 
                 for j, snippet in enumerate(struct.get("snippets", [])):
@@ -136,16 +129,9 @@ def search(
     credentials = load_gcp_credentials(SINGLETON.GOOGLE_APPLICATION_CREDENTIALS)
 
     location = SINGLETON.GOOGLE_CLOUD_LOCATION
-    # https://cloud.google.com/generative-ai-app-builder/docs/locations#specify_a_multi-region_for_your_data_store
-    client_options = (
-        ClientOptions(api_endpoint=f"{location}-discoveryengine.googleapis.com")
-        if location != "global"
-        else None
-    )
-
     client = discoveryengine.SearchServiceClient(
         credentials=credentials,
-        client_options=client_options,
+        client_options=discoveryengine_client_options(location),
     )
 
     datastore = datastore_override or SINGLETON.VERTEX_AI_DATASTORES[DatastoreKey.LAWS]
@@ -185,6 +171,14 @@ def search(
         corrected_query=pager.corrected_query,
         results=list(pager),
     )
+
+
+def _print_passages(key: str, items: list, *, width: int) -> None:
+    for j, item in enumerate(items):
+        content = repair_mojibake(item.get("content", ""))
+        page = item.get("pageNumber", "?")
+        print(f"  {key}[{j}] (page {page}):")
+        print(_wrap(content, width=width))
 
 
 def _wrap(text: str, *, width: int) -> str:

--- a/backend/scripts/vertex_ai_search.py
+++ b/backend/scripts/vertex_ai_search.py
@@ -24,7 +24,10 @@ from typing import Literal
 from google.cloud import discoveryengine_v1beta as discoveryengine
 
 from tenantfirstaid.constants import SINGLETON, DatastoreKey
-from tenantfirstaid.google_auth import discoveryengine_client_options, load_gcp_credentials
+from tenantfirstaid.google_auth import (
+    discoveryengine_client_options,
+    load_gcp_credentials,
+)
 from tenantfirstaid.langchain_tools import filter_builder, repair_mojibake
 from tenantfirstaid.location import OregonCity, UsaState
 
@@ -82,10 +85,14 @@ class SearchResults:
                     print(f"  link:   {link}")
 
                 _print_passages(
-                    "extractive_answer", struct.get("extractive_answers", []), width=width
+                    "extractive_answer",
+                    struct.get("extractive_answers", []),
+                    width=width,
                 )
                 _print_passages(
-                    "extractive_segment", struct.get("extractive_segments", []), width=width
+                    "extractive_segment",
+                    struct.get("extractive_segments", []),
+                    width=width,
                 )
 
                 for j, snippet in enumerate(struct.get("snippets", [])):

--- a/backend/scripts/vertex_ai_search.py
+++ b/backend/scripts/vertex_ai_search.py
@@ -64,7 +64,7 @@ class SearchResults:
                 out.append(Passage(doc_id=doc_id, type="segment", content=content))
         return out
 
-    def print(self, *, raw: bool = False, width: int = 100) -> None:
+    def display(self, *, raw: bool = False, width: int = 100) -> None:
         """Pretty-print these search results to stdout."""
         if self.corrected_query:
             print(f"Spell-corrected query: {self.corrected_query}\n")
@@ -84,12 +84,12 @@ class SearchResults:
                 if link:
                     print(f"  link:   {link}")
 
-                _print_passages(
+                self._print_passages(
                     "extractive_answer",
                     struct.get("extractive_answers", []),
                     width=width,
                 )
-                _print_passages(
+                self._print_passages(
                     "extractive_segment",
                     struct.get("extractive_segments", []),
                     width=width,
@@ -98,7 +98,7 @@ class SearchResults:
                 for j, snippet in enumerate(struct.get("snippets", [])):
                     text = repair_mojibake(snippet.get("snippet", ""))
                     print(f"  snippet[{j}]:")
-                    print(_wrap(text, width=width))
+                    print(self._wrap(text, width=width))
 
             if raw:
                 print("  raw_struct_data:")
@@ -119,6 +119,23 @@ class SearchResults:
             print("No results found.")
         else:
             print(f"({len(self.results)} results)")
+
+    @staticmethod
+    def _print_passages(key: str, items: list, *, width: int) -> None:
+        for j, item in enumerate(items):
+            content = repair_mojibake(item.get("content", ""))
+            page = item.get("pageNumber", "?")
+            print(f"  {key}[{j}] (page {page}):")
+            print(SearchResults._wrap(content, width=width))
+
+    @staticmethod
+    def _wrap(text: str, *, width: int) -> str:
+        return textwrap.fill(
+            text,
+            width=width,
+            initial_indent="    ",
+            subsequent_indent="    ",
+        )
 
 
 def search(
@@ -177,23 +194,6 @@ def search(
     return SearchResults(
         corrected_query=pager.corrected_query,
         results=list(pager),
-    )
-
-
-def _print_passages(key: str, items: list, *, width: int) -> None:
-    for j, item in enumerate(items):
-        content = repair_mojibake(item.get("content", ""))
-        page = item.get("pageNumber", "?")
-        print(f"  {key}[{j}] (page {page}):")
-        print(_wrap(content, width=width))
-
-
-def _wrap(text: str, *, width: int) -> str:
-    return textwrap.fill(
-        text,
-        width=width,
-        initial_indent="    ",
-        subsequent_indent="    ",
     )
 
 
@@ -394,7 +394,7 @@ def main() -> None:
         datastore_override=datastore,
     )
 
-    response.print(raw=args.raw, width=args.width)
+    response.display(raw=args.raw, width=args.width)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/vertex_ai_search.py
+++ b/backend/scripts/vertex_ai_search.py
@@ -52,7 +52,7 @@ def search(
     """Run a search against the Vertex AI Search datastore and return the raw response."""
     credentials = load_gcp_credentials(SINGLETON.GOOGLE_APPLICATION_CREDENTIALS)
 
-    location = SINGLETON.GOOGLE_CLOUD_LOCATION or "global"
+    location = SINGLETON.GOOGLE_CLOUD_LOCATION
     client_options = (
         ClientOptions(api_endpoint=f"{location}-discoveryengine.googleapis.com")
         if location != "global"
@@ -235,7 +235,7 @@ def _shmoo(
     # Sweep extractive answers (segments fixed at 1).
     print(f"{'answers':>8}  {'hits':>4}  where")
     print(f"{'-------':>8}  {'----':>4}  -----")
-    prev_hit_count = -1
+    prev_hit_count = 0
     for n in range(1, max_answer_sweep + 1):
         response = search(
             query,
@@ -258,7 +258,7 @@ def _shmoo(
     # Sweep extractive segments (answers fixed at 1).
     print(f"{'segments':>8}  {'hits':>4}  where")
     print(f"{'--------':>8}  {'----':>4}  -----")
-    prev_hit_count = -1
+    prev_hit_count = 0
     for n in range(1, max_segment_sweep + 1):
         response = search(
             query,

--- a/backend/scripts/vertex_ai_search.py
+++ b/backend/scripts/vertex_ai_search.py
@@ -22,20 +22,24 @@ from typing import TypedDict
 
 from google.api_core.client_options import ClientOptions
 from google.cloud import discoveryengine_v1beta as discoveryengine
-from google.cloud.discoveryengine_v1beta.services.search_service.pagers import (
-    SearchPager,
-)
 
 from tenantfirstaid.constants import SINGLETON, DatastoreKey
 from tenantfirstaid.google_auth import load_gcp_credentials
 from tenantfirstaid.langchain_tools import filter_builder, repair_mojibake
 from tenantfirstaid.location import OregonCity, UsaState
 
+SearchResult = discoveryengine.SearchResponse.SearchResult
+
 
 class Passage(TypedDict):
     doc_id: str
     type: str
     content: str
+
+
+class SearchResults(TypedDict):
+    corrected_query: str
+    results: list[SearchResult]
 
 
 def search(
@@ -46,13 +50,14 @@ def search(
     max_results: int = 5,
     max_extractive_answer_count: int = 5,
     max_extractive_segment_count: int = 3,
-    spell_correction: int = 1,
+    spell_correction: discoveryengine.SearchRequest.SpellCorrectionSpec.Mode = discoveryengine.SearchRequest.SpellCorrectionSpec.Mode.AUTO,
     datastore_override: str | None = None,
-) -> SearchPager:
-    """Run a search against the Vertex AI Search datastore and return the raw response."""
+) -> SearchResults:
+    """Run a search against the Vertex AI Search datastore and return results."""
     credentials = load_gcp_credentials(SINGLETON.GOOGLE_APPLICATION_CREDENTIALS)
 
     location = SINGLETON.GOOGLE_CLOUD_LOCATION
+    # https://cloud.google.com/generative-ai-app-builder/docs/locations#specify_a_multi-region_for_your_data_store
     client_options = (
         ClientOptions(api_endpoint=f"{location}-discoveryengine.googleapis.com")
         if location != "global"
@@ -96,13 +101,17 @@ def search(
         spell_correction_spec=spell_correction_spec,
     )
 
-    return client.search(request)
+    pager = client.search(request)
+    return SearchResults(
+        corrected_query=pager.corrected_query,
+        results=list(pager),
+    )
 
 
-def _collect_passages(response: SearchPager) -> list[Passage]:
+def _collect_passages(response: SearchResults) -> list[Passage]:
     """Collect all extractive answers and segments from a search response."""
     passages: list[Passage] = []
-    for result in response.results:
+    for result in response["results"]:
         doc = result.document
         struct = doc.derived_struct_data
         if not struct:
@@ -118,17 +127,17 @@ def _collect_passages(response: SearchPager) -> list[Passage]:
 
 
 def _print_results(
-    response: SearchPager,
+    response: SearchResults,
     *,
     raw: bool = False,
     width: int = 100,
 ) -> None:
     """Pretty-print search results to stdout."""
-    if hasattr(response, "corrected_query") and response.corrected_query:
-        print(f"Spell-corrected query: {response.corrected_query}\n")
+    if response["corrected_query"]:
+        print(f"Spell-corrected query: {response['corrected_query']}\n")
 
     count = 0
-    for i, result in enumerate(response.results, 1):
+    for i, result in enumerate(response["results"], 1):
         count = i
         doc = result.document
         struct = doc.derived_struct_data
@@ -215,12 +224,15 @@ def _shmoo(
     targets_lower = [t.lower() for t in targets]
 
     def _check(passages: list[Passage]) -> list[str]:
-        """Return list of strings of the form "doc_id:type" where any target matched."""
+        """Return deduplicated list of strings of the form "doc_id:type" where any target matched."""
+        seen: set[str] = set()
         hits = []
         for p in passages:
+            key = f"{p['doc_id']}:{p['type']}"
             content_lower = p["content"].lower()
-            if any(t in content_lower for t in targets_lower):
-                hits.append(f"{p['doc_id']}:{p['type']}")
+            if key not in seen and any(t in content_lower for t in targets_lower):
+                seen.add(key)
+                hits.append(key)
         return hits
 
     print(f"Query:   {query}")

--- a/backend/tenantfirstaid/constants.py
+++ b/backend/tenantfirstaid/constants.py
@@ -105,8 +105,12 @@ class _GoogEnvAndPolicy:
             ("GOOGLE_CLOUD_LOCATION", _gcp_location),
             ("GOOGLE_APPLICATION_CREDENTIALS", _gcp_creds),
         ):
-            if value is None:
-                raise ValueError(f"[{name}] environment variable is not set.")
+            # Catches both unset (None) and explicitly empty (e.g. VAR="").
+            # Does not catch whitespace-only values.
+            if not value:
+                raise ValueError(
+                    f"[{name}] environment variable is not set or is empty."
+                )
 
         self.MODEL_NAME: Final[str] = cast(str, _model_name)
         self.GOOGLE_CLOUD_PROJECT: Final[str] = cast(str, _gcp_project)

--- a/backend/tenantfirstaid/constants.py
+++ b/backend/tenantfirstaid/constants.py
@@ -2,7 +2,7 @@ import os
 from collections.abc import Mapping
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import Final, Optional
+from typing import Final, Optional, cast
 
 from dotenv import load_dotenv
 from langchain_google_genai import HarmBlockThreshold, HarmCategory
@@ -91,24 +91,27 @@ class _GoogEnvAndPolicy:
         if path_to_env.exists():
             load_dotenv(override=True)
 
-        # Assign & Check slot attributes for required environment variables
+        # Assign & Check slot attributes for required environment variables.
         # Note: assign explicitly since typecheckers do not understand slotted attributes
         #       that are assigned by __setattr__()
-        self.MODEL_NAME: Final = os.getenv("MODEL_NAME")
-        self.GOOGLE_CLOUD_PROJECT: Final = os.getenv("GOOGLE_CLOUD_PROJECT")
-        self.GOOGLE_CLOUD_LOCATION: Final = os.getenv("GOOGLE_CLOUD_LOCATION")
-        self.GOOGLE_APPLICATION_CREDENTIALS: Final = os.getenv(
-            "GOOGLE_APPLICATION_CREDENTIALS"
-        )
+        _model_name = os.getenv("MODEL_NAME")
+        _gcp_project = os.getenv("GOOGLE_CLOUD_PROJECT")
+        _gcp_location = os.getenv("GOOGLE_CLOUD_LOCATION")
+        _gcp_creds = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
 
-        for c in (
-            "MODEL_NAME",
-            "GOOGLE_CLOUD_PROJECT",
-            "GOOGLE_CLOUD_LOCATION",
-            "GOOGLE_APPLICATION_CREDENTIALS",
+        for name, value in (
+            ("MODEL_NAME", _model_name),
+            ("GOOGLE_CLOUD_PROJECT", _gcp_project),
+            ("GOOGLE_CLOUD_LOCATION", _gcp_location),
+            ("GOOGLE_APPLICATION_CREDENTIALS", _gcp_creds),
         ):
-            if getattr(self, c) is None:
-                raise ValueError(f"[{c}] environment variable is not set.")
+            if value is None:
+                raise ValueError(f"[{name}] environment variable is not set.")
+
+        self.MODEL_NAME: Final[str] = cast(str, _model_name)
+        self.GOOGLE_CLOUD_PROJECT: Final[str] = cast(str, _gcp_project)
+        self.GOOGLE_CLOUD_LOCATION: Final[str] = cast(str, _gcp_location)
+        self.GOOGLE_APPLICATION_CREDENTIALS: Final[str] = cast(str, _gcp_creds)
 
         # _parse_datastores raises ValueError if any matched var is set but empty.
         self.VERTEX_AI_DATASTORES: Final[dict[str, str]] = _parse_datastores(os.environ)

--- a/backend/tenantfirstaid/google_auth.py
+++ b/backend/tenantfirstaid/google_auth.py
@@ -7,8 +7,21 @@ Supports both file-path credentials (local development) and inline JSON
 import json
 from pathlib import Path
 
+from google.api_core.client_options import ClientOptions
 from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
+
+
+def discoveryengine_client_options(location: str) -> ClientOptions | None:
+    """Return ClientOptions for the Discovery Engine API endpoint.
+
+    Returns None for the "global" location so the client uses its default
+    endpoint. All other locations use a regional endpoint.
+    See: https://cloud.google.com/generative-ai-app-builder/docs/locations#specify_a_multi-region_for_your_data_store
+    """
+    if location == "global":
+        return None
+    return ClientOptions(api_endpoint=f"{location}-discoveryengine.googleapis.com")
 
 
 def _parse_inline_json(raw: str) -> dict:

--- a/backend/tenantfirstaid/langchain_tools.py
+++ b/backend/tenantfirstaid/langchain_tools.py
@@ -126,6 +126,11 @@ class RagBuilder:
 
 
 def filter_builder(state: UsaState, city: Optional[OregonCity] = None) -> str:
+    """Build a Vertex AI Search filter string for the given state and optional city.
+
+    City-scoped queries include both city-specific and state-level ("null") documents
+    so the agent sees both layers of law in a single retrieval.
+    """
     if city is None:
         city_filter = 'city: ANY("null")'
     else:

--- a/backend/tenantfirstaid/langchain_tools.py
+++ b/backend/tenantfirstaid/langchain_tools.py
@@ -31,7 +31,7 @@ from .location import OregonCity, UsaState
 logger = logging.getLogger(__name__)
 
 
-def _repair_mojibake(text: str) -> str:
+def repair_mojibake(text: str) -> str:
     """Attempt to repair UTF-8 text that was incorrectly decoded as Latin-1.
 
     Vertex AI may return corpus text with mojibake (e.g. â€™ instead of ')
@@ -122,10 +122,10 @@ class RagBuilder:
             input=query,
         )
 
-        return "\n".join([_repair_mojibake(doc.page_content) for doc in docs])
+        return "\n".join([repair_mojibake(doc.page_content) for doc in docs])
 
 
-def _filter_builder(state: UsaState, city: Optional[OregonCity] = None) -> str:
+def filter_builder(state: UsaState, city: Optional[OregonCity] = None) -> str:
     if city is None:
         city_filter = 'city: ANY("null")'
     else:
@@ -242,12 +242,12 @@ class CityStateLawsInputSchema(BaseModel):
 
 
 def _default_filter_from_city_state(**kwargs: object) -> str:
-    """Adapter that extracts state/city from tool kwargs and calls _filter_builder.
+    """Adapter that extracts state/city from tool kwargs and calls filter_builder.
 
     All other kwargs (query, max_documents, etc.) are intentionally ignored;
     custom filter_builders may use them if needed.
     """
-    return _filter_builder(
+    return filter_builder(
         state=cast(UsaState, kwargs["state"]),
         city=cast(Optional[OregonCity], kwargs.get("city")),
     )

--- a/backend/tests/test_langchain_tools.py
+++ b/backend/tests/test_langchain_tools.py
@@ -19,12 +19,12 @@ from tenantfirstaid.google_auth import load_gcp_credentials
 from tenantfirstaid.langchain_tools import (
     CityStateLawsInputSchema,
     RagBuilder,
-    _filter_builder,
     _make_rag_tool,
-    _repair_mojibake,
+    filter_builder,
     generate_letter,
     get_active_rag_tools,
     get_letter_template,
+    repair_mojibake,
     retrieve_city_state_laws,
     retrieve_oregon_law_help,
 )
@@ -205,19 +205,19 @@ def test_retrieve_city_state_laws_returns_joined_docs(mock_rag_class):
     assert "Doc2 content" in result
 
 
-# --- _repair_mojibake property tests ---
+# --- repair_mojibake property tests ---
 
 
 @pytest.mark.property
 @given(st.text(alphabet=st.characters(max_codepoint=0x7F)))
-def test_repair_mojibake_ascii_unchanged(text: str) -> None:
+def testrepair_mojibake_ascii_unchanged(text: str) -> None:
     """Pure ASCII text is returned unchanged — no mojibake to repair."""
-    assert _repair_mojibake(text) == text
+    assert repair_mojibake(text) == text
 
 
 @pytest.mark.property
 @given(st.text(alphabet=st.characters(blacklist_categories=("Cs",))))
-def test_repair_mojibake_repairs_genuine_mojibake(original: str) -> None:
+def testrepair_mojibake_repairs_genuine_mojibake(original: str) -> None:
     """Genuine mojibake (UTF-8 bytes misread as Latin-1) is fully repaired.
 
     Simulates the Vertex AI encoding defect: the original string's UTF-8
@@ -229,14 +229,14 @@ def test_repair_mojibake_repairs_genuine_mojibake(original: str) -> None:
     before reaching the function under test.
     """
     mojibake = original.encode("utf-8").decode("latin-1")
-    assert _repair_mojibake(mojibake) == original
+    assert repair_mojibake(mojibake) == original
 
 
 @pytest.mark.property
 @given(
     st.text(alphabet=st.characters(min_codepoint=0x80, max_codepoint=0xBF), min_size=1)
 )
-def test_repair_mojibake_continuation_byte_chars_unchanged(text: str) -> None:
+def testrepair_mojibake_continuation_byte_chars_unchanged(text: str) -> None:
     """Text with chars in U+0080–U+00BF is returned unchanged.
 
     These chars (including § U+00A7) encode to Latin-1 bytes 0x80–0xBF,
@@ -245,7 +245,7 @@ def test_repair_mojibake_continuation_byte_chars_unchanged(text: str) -> None:
     original text is returned as-is. This covers the Vertex AI defect
     where the leading 0xC2 byte of a UTF-8 § sequence is dropped.
     """
-    assert _repair_mojibake(text) == text
+    assert repair_mojibake(text) == text
 
 
 @patch("tenantfirstaid.langchain_tools.RagBuilder")
@@ -295,7 +295,7 @@ def test_get_active_rag_tools_filters_by_configured_datastores():
 
 
 @patch("tenantfirstaid.langchain_tools.RagBuilder")
-def test_make_rag_tool_custom_filter_builder(mock_rag_class):
+def test_make_rag_tool_customfilter_builder(mock_rag_class):
     """Custom filter_builder is called instead of the default."""
     mock_rag_class.return_value.search.return_value = ""
     custom_filter = MagicMock(return_value="custom-filter")
@@ -331,16 +331,16 @@ def test_make_rag_tool_custom_filter_builder(mock_rag_class):
     )
 
 
-def test_filter_builder_state_only():
+def testfilter_builder_state_only():
     """Test filter with state only (no city) produces null city."""
-    result = _filter_builder(UsaState("or"), None)
+    result = filter_builder(UsaState("or"), None)
     assert 'city: ANY("null")' in result
     assert 'state: ANY("or")' in result
 
 
-def test_filter_builder_with_city():
+def testfilter_builder_with_city():
     """Test filter with city includes state-level docs."""
-    result = _filter_builder(UsaState("or"), OregonCity("eugene"))
+    result = filter_builder(UsaState("or"), OregonCity("eugene"))
     assert 'city: ANY("eugene", "null")' in result
     assert 'state: ANY("or")' in result
 

--- a/backend/tests/test_langchain_tools.py
+++ b/backend/tests/test_langchain_tools.py
@@ -210,14 +210,14 @@ def test_retrieve_city_state_laws_returns_joined_docs(mock_rag_class):
 
 @pytest.mark.property
 @given(st.text(alphabet=st.characters(max_codepoint=0x7F)))
-def testrepair_mojibake_ascii_unchanged(text: str) -> None:
+def test_repair_mojibake_ascii_unchanged(text: str) -> None:
     """Pure ASCII text is returned unchanged — no mojibake to repair."""
     assert repair_mojibake(text) == text
 
 
 @pytest.mark.property
 @given(st.text(alphabet=st.characters(blacklist_categories=("Cs",))))
-def testrepair_mojibake_repairs_genuine_mojibake(original: str) -> None:
+def test_repair_mojibake_repairs_genuine_mojibake(original: str) -> None:
     """Genuine mojibake (UTF-8 bytes misread as Latin-1) is fully repaired.
 
     Simulates the Vertex AI encoding defect: the original string's UTF-8
@@ -236,7 +236,7 @@ def testrepair_mojibake_repairs_genuine_mojibake(original: str) -> None:
 @given(
     st.text(alphabet=st.characters(min_codepoint=0x80, max_codepoint=0xBF), min_size=1)
 )
-def testrepair_mojibake_continuation_byte_chars_unchanged(text: str) -> None:
+def test_repair_mojibake_continuation_byte_chars_unchanged(text: str) -> None:
     """Text with chars in U+0080–U+00BF is returned unchanged.
 
     These chars (including § U+00A7) encode to Latin-1 bytes 0x80–0xBF,
@@ -295,7 +295,7 @@ def test_get_active_rag_tools_filters_by_configured_datastores():
 
 
 @patch("tenantfirstaid.langchain_tools.RagBuilder")
-def test_make_rag_tool_customfilter_builder(mock_rag_class):
+def test_make_rag_tool_custom_filter_builder(mock_rag_class):
     """Custom filter_builder is called instead of the default."""
     mock_rag_class.return_value.search.return_value = ""
     custom_filter = MagicMock(return_value="custom-filter")
@@ -331,14 +331,14 @@ def test_make_rag_tool_customfilter_builder(mock_rag_class):
     )
 
 
-def testfilter_builder_state_only():
+def test_filter_builder_state_only():
     """Test filter with state only (no city) produces null city."""
     result = filter_builder(UsaState("or"), None)
     assert 'city: ANY("null")' in result
     assert 'state: ANY("or")' in result
 
 
-def testfilter_builder_with_city():
+def test_filter_builder_with_city():
     """Test filter with city includes state-level docs."""
     result = filter_builder(UsaState("or"), OregonCity("eugene"))
     assert 'city: ANY("eugene", "null")' in result


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Maintenance

## Description

New `backend/scripts/vertex_ai_search.py` that queries the Vertex AI Search datastore directly, bypassing LangChain/LangGraph. Useful for debugging retrieval quality independently of the agent — see exactly what passages the datastore returns for a given query and filter.

**`search` subcommand** — runs a single query with optional city/state filter, prints passages with source metadata.

**`shmoo` subcommand** — sweeps `max_extractive_answer_count` and `max_extractive_segment_count` combinations against a target string to find the extraction params that surface a specific passage.

**`--datastore` flag** — override `VERTEX_AI_DATASTORE_LAWS` from the environment to test alternate corpora without changing `.env`.

**`--raw` flag** — print the full API response JSON.

> **Merge order:** merge #324 first. This branch is based on `pr/rag-bug-fixes` and will need to be rebased on `main` after #324 lands.

## Related Tickets & Documents

- Depends on #324

## QA Instructions, Screenshots, Recordings

```bash
cd backend
# requires GOOGLE_APPLICATION_CREDENTIALS and VERTEX_AI_DATASTORE_LAWS in .env
uv run python -m scripts.vertex_ai_search search "security deposit interest" --state or
uv run python -m scripts.vertex_ai_search shmoo "72 hour nonpayment notice" --target "fifth day" --state or
```

## Added/updated tests?

- [ ] No, and this is why: standalone debugging script with no branching logic to unit-test; correctness is verified by running against the live datastore

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?