### PR TITLE
rewrite @claude workflow to work on forks but with fewer permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,18 +20,12 @@ jobs:
       issues: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      - name: Resolve PR number
-        id: pr
-        run: |
-          echo "number=${PR_NUMBER:-$ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
       - name: Find code snapshot
         id: snapshot
         run: |
-          WORKFLOW_URL="https://github.com/${GITHUB_REPOSITORY}/actions/workflows/pr-check.yml"
+          # Artifact name format must match the upload in pr-check.yml snapshot job.
+          PR_NUMBER="${PR_NUMBER_PR:-$PR_NUMBER_ISSUE}"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/workflows/pr-check.yml"
           MAX_ATTEMPTS=8
           SLEEP_SECONDS=15
 
@@ -69,7 +63,8 @@ jobs:
           exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_NUMBER_ISSUE: ${{ github.event.issue.number }}
+          PR_NUMBER_PR: ${{ github.event.pull_request.number }}
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   claude:
     if: |
+      github.repository == 'codeforpdx/tenantfirstaid' &&
       contains(github.event.comment.body, '@claude') &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
@@ -35,19 +36,16 @@ jobs:
           SLEEP_SECONDS=15
 
           HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
-          COMMIT_TIME=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}" \
-            --jq '.commit.committer.date')
+          ARTIFACT_NAME="pr-${PR_NUMBER}-code-${HEAD_SHA}"
 
           for i in $(seq 1 $MAX_ATTEMPTS); do
-            RESULT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=pr-${PR_NUMBER}-code&per_page=1" \
+            RESULT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=1" \
               --jq '.artifacts[0] | select(.expired == false)')
 
             if [ -n "$RESULT" ] && [ "$RESULT" != "null" ]; then
-              ARTIFACT_TIME=$(echo "$RESULT" | jq -r '.created_at')
-              if [[ "$ARTIFACT_TIME" > "$COMMIT_TIME" ]]; then
-                echo "run_id=$(echo "$RESULT" | jq -r '.workflow_run.id')" >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
+              echo "run_id=$(echo "$RESULT" | jq -r '.workflow_run.id')" >> "$GITHUB_OUTPUT"
+              echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
 
             BUCKET=$(gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
@@ -75,7 +73,7 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: pr-${{ steps.pr.outputs.number }}-code
+          name: ${{ steps.snapshot.outputs.artifact_name }}
           run-id: ${{ steps.snapshot.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,6 +4,11 @@ name: Claude Code
 # came from a fork — secrets and GITHUB_TOKEN write permissions are always available.
 # This is the property that makes issue_comment safe to use with privileged jobs,
 # unlike pull_request which runs in the fork's context without secrets.
+env:
+  # Base tool allowlist shared by both jobs. WebFetch is restricted to known
+  # documentation domains to prevent exfiltration via outbound HTTP.
+  ALLOWED_TOOLS: "Read,WebFetch(domain:docs.langchain.com),WebFetch(domain:reference.langchain.com),WebFetch(domain:ai.google.dev),WebFetch(domain:docs.digitalocean.com),WebFetch(domain:docs.github.com),WebFetch(domain:docs.docker.com),WebFetch(domain:docs.astral.sh)"
+
 on:
   issue_comment:
     types: [created]
@@ -38,7 +43,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --allowedTools Read,Edit,Write,WebFetch(domain:docs.langchain.com),WebFetch(domain:reference.langchain.com),WebFetch(domain:ai.google.dev),WebFetch(domain:docs.digitalocean.com),WebFetch(domain:docs.github.com),WebFetch(domain:docs.docker.com),WebFetch(domain:docs.astral.sh)
+            --allowedTools ${{ env.ALLOWED_TOOLS }},Edit,Write
 
   # Handles @claude on PRs — both inline review comments and conversation-tab comments.
   # Read-only: Claude can review and comment but cannot push commits.
@@ -126,4 +131,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --allowedTools Read,WebFetch(domain:docs.langchain.com),WebFetch(domain:reference.langchain.com),WebFetch(domain:ai.google.dev),WebFetch(domain:docs.digitalocean.com),WebFetch(domain:docs.github.com),WebFetch(domain:docs.docker.com),WebFetch(domain:docs.astral.sh)
+            --allowedTools ${{ env.ALLOWED_TOOLS }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,41 +8,40 @@ on:
 
 jobs:
   claude:
-    if: contains(github.event.comment.body, '@claude')
+    if: |
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      # Step 1: Get PR info for fork detection
-      - name: Get PR info for fork support
-        if: github.event.issue.pull_request
-        id: pr-info
+      - name: Resolve checkout ref
+        id: ref
         run: |
-          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
-          echo "pr_head_owner=$(echo "$PR_DATA" | jq -r '.head.repo.owner.login')" >> $GITHUB_OUTPUT
-          echo "pr_head_repo=$(echo "$PR_DATA" | jq -r '.head.repo.name')" >> $GITHUB_OUTPUT
-          echo "pr_head_ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> $GITHUB_OUTPUT
-          echo "is_fork=$(echo "$PR_DATA" | jq -r '.head.repo.fork')" >> $GITHUB_OUTPUT
+          if [ -n "$ISSUE_PR_URL" ] || [ -n "$PR_NUMBER" ]; then
+            PR="${PR_NUMBER:-$ISSUE_NUMBER}"
+            echo "ref=refs/pull/${PR}/merge" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${GITHUB_REF}" >> "$GITHUB_OUTPUT"
+          fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
-      # Step 2: Checkout repository (fork or base)
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      # refs/pull/<N>/merge is a GitHub-managed ref on the base repo containing
+      # the pre-merged PR code — works for fork and local branch PRs alike.
+      - uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.issue.pull_request && steps.pr-info.outputs.is_fork == 'true' && format('{0}/{1}', steps.pr-info.outputs.pr_head_owner, steps.pr-info.outputs.pr_head_repo) || github.repository }}
-          ref: ${{ github.event.issue.pull_request && steps.pr-info.outputs.pr_head_ref || github.ref }}
+          ref: ${{ steps.ref.outputs.ref }}
           fetch-depth: 1
 
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-           --allowedTools Read,Edit,Write,WebFetch
+            --allowedTools Read,WebFetch(domain:docs.langchain.com),WebFetch(domain:reference.langchain.com),WebFetch(domain:ai.google.dev),WebFetch(domain:docs.digitalocean.com),WebFetch(domain:docs.github.com),WebFetch(domain:docs.docker.com),WebFetch(domain:docs.astral.sh)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,7 +24,10 @@ jobs:
         run: |
           if [ -n "$ISSUE_PR_URL" ] || [ -n "$PR_NUMBER" ]; then
             PR="${PR_NUMBER:-$ISSUE_NUMBER}"
-            echo "ref=refs/pull/${PR}/merge" >> "$GITHUB_OUTPUT"
+            # Resolve to a fixed SHA so the checkout is immune to race conditions
+            # between comment time and checkout time (TOCTOU).
+            SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq '.merge_commit_sha')
+            echo "ref=${SHA}" >> "$GITHUB_OUTPUT"
           else
             echo "ref=${GITHUB_REF}" >> "$GITHUB_OUTPUT"
           fi
@@ -32,9 +35,10 @@ jobs:
           ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # refs/pull/<N>/merge is a GitHub-managed ref on the base repo containing
-      # the pre-merged PR code — works for fork and local branch PRs alike.
+      # Checks out the merge commit SHA computed by GitHub at comment time — works
+      # for fork and local branch PRs alike without checking out the fork repo.
       - uses: actions/checkout@v6
         with:
           ref: ${{ steps.ref.outputs.ref }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,27 +1,73 @@
 name: Claude Code
 
+# Both triggers fire in the base repo context regardless of whether the comment
+# came from a fork — secrets and GITHUB_TOKEN write permissions are always available.
+# This is the property that makes issue_comment safe to use with privileged jobs,
+# unlike pull_request which runs in the fork's context without secrets.
 on:
   issue_comment:
     types: [created]
+  # pull_request_review_comment covers inline code-review comments only.
+  # Conversation-tab comments on PRs arrive as issue_comment, not this event.
   pull_request_review_comment:
     types: [created]
 
 jobs:
-  claude:
+  # Handles @claude on plain issues (no associated PR).
+  # Has write permissions so Claude can implement changes and open a PR.
+  claude-issue:
     if: |
       github.repository == 'codeforpdx/tenantfirstaid' &&
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    # Repo check prevents ANTHROPIC_API_KEY from being used if this workflow is
+    # copied to a fork, even though the secret would be absent there anyway.
+    # Author association check prevents arbitrary commenters from burning API quota.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write      # Needed to push commits and open PRs.
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowedTools Read,Edit,Write,WebFetch(domain:docs.langchain.com),WebFetch(domain:reference.langchain.com),WebFetch(domain:ai.google.dev),WebFetch(domain:docs.digitalocean.com),WebFetch(domain:docs.github.com),WebFetch(domain:docs.docker.com),WebFetch(domain:docs.astral.sh)
+
+  # Handles @claude on PRs — both inline review comments and conversation-tab comments.
+  # Read-only: Claude can review and comment but cannot push commits.
+  # PR conversation-tab comments arrive as issue_comment with issue.pull_request set;
+  # inline review comments arrive as pull_request_review_comment. Both are routed here.
+  claude-pr:
+    if: |
+      github.repository == 'codeforpdx/tenantfirstaid' &&
+      (github.event_name == 'pull_request_review_comment' || github.event.issue.pull_request != null) &&
       contains(github.event.comment.body, '@claude') &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      actions: read # Required for Claude to read CI results on PRs
+      contents: read       # Read-only: prevents Claude from pushing to the repo.
+      pull-requests: write # Needed to post review comments.
+      issues: write        # Needed to file follow-up issues from a review.
+      actions: read        # Needed to read CI check results on the PR.
     steps:
       - name: Find code snapshot
         id: snapshot
+        # The pr-check.yml snapshot job uploads the PR code as an artifact on each push,
+        # named by PR number and head SHA. We look up that artifact here rather than
+        # checking out the fork directly, so the privileged job never executes untrusted
+        # code — only reads files that the unprivileged snapshot job already captured.
+        #
+        # PR number comes from different fields depending on the trigger:
+        #   pull_request_review_comment → github.event.pull_request.number (PR_NUMBER_PR)
+        #   issue_comment on a PR       → github.event.issue.number (PR_NUMBER_ISSUE)
         run: |
           # Artifact name format must match the upload in pr-check.yml snapshot job.
           PR_NUMBER="${PR_NUMBER_PR:-$PR_NUMBER_ISSUE}"
@@ -29,6 +75,8 @@ jobs:
           MAX_ATTEMPTS=8
           SLEEP_SECONDS=15
 
+          # HEAD_SHA must be fetched via API because neither trigger event carries
+          # the PR head SHA directly in its payload.
           HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
           ARTIFACT_NAME="pr-${PR_NUMBER}-code-${HEAD_SHA}"
 
@@ -42,6 +90,8 @@ jobs:
               exit 0
             fi
 
+            # If the snapshot job is still running, wait and retry.
+            # If it is not pending (failed, never ran, etc.), fail immediately.
             BUCKET=$(gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
               --json name,bucket \
               --jq '.[] | select(.name == "snapshot") | .bucket' 2>/dev/null || echo "")

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,37 +12,72 @@ jobs:
       contains(github.event.comment.body, '@claude') &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
       issues: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      - name: Resolve checkout ref
-        id: ref
+      - name: Resolve PR number
+        id: pr
         run: |
-          if [ -n "$ISSUE_PR_URL" ] || [ -n "$PR_NUMBER" ]; then
-            PR="${PR_NUMBER:-$ISSUE_NUMBER}"
-            # Resolve to a fixed SHA so the checkout is immune to race conditions
-            # between comment time and checkout time (TOCTOU).
-            SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq '.merge_commit_sha')
-            echo "ref=${SHA}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=${GITHUB_REF}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "number=${PR_NUMBER:-$ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
         env:
-          ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Checks out the merge commit SHA computed by GitHub at comment time — works
-      # for fork and local branch PRs alike without checking out the fork repo.
-      - uses: actions/checkout@v6
+      - name: Find code snapshot
+        id: snapshot
+        run: |
+          WORKFLOW_URL="https://github.com/${GITHUB_REPOSITORY}/actions/workflows/pr-check.yml"
+          MAX_ATTEMPTS=8
+          SLEEP_SECONDS=15
+
+          HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          COMMIT_TIME=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}" \
+            --jq '.commit.committer.date')
+
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            RESULT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=pr-${PR_NUMBER}-code&per_page=1" \
+              --jq '.artifacts[0] | select(.expired == false)')
+
+            if [ -n "$RESULT" ] && [ "$RESULT" != "null" ]; then
+              ARTIFACT_TIME=$(echo "$RESULT" | jq -r '.created_at')
+              if [[ "$ARTIFACT_TIME" > "$COMMIT_TIME" ]]; then
+                echo "run_id=$(echo "$RESULT" | jq -r '.workflow_run.id')" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+
+            BUCKET=$(gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --json name,bucket \
+              --jq '.[] | select(.name == "snapshot") | .bucket' 2>/dev/null || echo "")
+
+            if [ "$BUCKET" != "pending" ]; then
+              gh issue comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                --body "No code snapshot is available for this PR. The snapshot job may not have run or may have failed — check the [PR checks workflow](${WORKFLOW_URL}) and re-trigger by commenting \`@claude\` once it completes."
+              exit 1
+            fi
+
+            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Snapshot job still running (attempt $i/$MAX_ATTEMPTS), waiting ${SLEEP_SECONDS}s..."
+              sleep $SLEEP_SECONDS
+            fi
+          done
+
+          gh issue comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --body "Timed out waiting for the code snapshot to be ready. The [PR checks workflow](${WORKFLOW_URL}) is taking longer than expected — please re-trigger by commenting \`@claude\` once it completes."
+          exit 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+
+      - uses: actions/download-artifact@v8
         with:
-          ref: ${{ steps.ref.outputs.ref }}
-          fetch-depth: 1
+          name: pr-${{ steps.pr.outputs.number }}-code
+          run-id: ${{ steps.snapshot.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,6 +12,34 @@ on:
       - "releases/*"
 
 jobs:
+  # This job captures a snapshot of the PR code at the head SHA and uploads it as an artifact.
+  # The claude-pr job later looks up this artifact to provide Claude with the PR code, since
+  # claude-pr cannot access the PR code directly to avoid execution of untrusted code from the
+  # PR in the claude-code context.
+  snapshot:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      # Artifact name format must match the lookup in claude.yml Find code snapshot step.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pr-${{ github.event.pull_request.number }}-code-${{ github.event.pull_request.head.sha }}
+          path: |
+            .
+            !.git
+            !node_modules
+            !backend/.venv
+            !**/__pycache__
+          retention-days: 10
+
   backend-test:
     runs-on: ubuntu-latest
     defaults:
@@ -82,30 +110,6 @@ jobs:
       - name: Run additional tests that require repo secrets
         if: env.PR_FROM_FORK != 'true'
         run: uv run pytest -v -s -m "require_repo_secrets" --cov --cov-append --cov-report term-missing
-
-  snapshot:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 1
-
-      # Artifact name format must match the lookup in claude.yml Find code snapshot step.
-      - uses: actions/upload-artifact@v7
-        with:
-          name: pr-${{ github.event.pull_request.number }}-code-${{ github.event.pull_request.head.sha }}
-          path: |
-            .
-            !.git
-            !node_modules
-            !backend/.venv
-            !**/__pycache__
-          retention-days: 10
 
   frontend-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -83,6 +83,29 @@ jobs:
         if: env.PR_FROM_FORK != 'true'
         run: uv run pytest -v -s -m "require_repo_secrets" --cov --cov-append --cov-report term-missing
 
+  snapshot:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pr-${{ github.event.pull_request.number }}-code
+          path: |
+            .
+            !.git
+            !node_modules
+            !backend/.venv
+            !**/__pycache__
+          retention-days: 10
+          overwrite: true
+
   frontend-build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: pr-${{ github.event.pull_request.number }}-code
+          name: pr-${{ github.event.pull_request.number }}-code-${{ github.event.pull_request.head.sha }}
           path: |
             .
             !.git
@@ -104,7 +104,6 @@ jobs:
             !backend/.venv
             !**/__pycache__
           retention-days: 10
-          overwrite: true
 
   frontend-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -86,6 +86,7 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:
@@ -94,6 +95,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
+      # Artifact name format must match the lookup in claude.yml Find code snapshot step.
       - uses: actions/upload-artifact@v7
         with:
           name: pr-${{ github.event.pull_request.number }}-code-${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Infrastructure
- [ ] Maintenance

## Description

at-claude triggers on branches on forked repos is no longer working.  This is an attempt to fix that and also apply the least-privilege principle.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note on the devices and browsers this has been tested on, as well as any relevant images for UI changes._


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?
