### PR TITLE
add id-token: write to claude workflow jobs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,7 @@ jobs:
       contents: write      # Needed to push commits and open PRs.
       pull-requests: write
       issues: write
+      id-token: write      # Required by claude-code-action for internal token management.
     steps:
       - uses: actions/checkout@v6
 
@@ -62,6 +63,7 @@ jobs:
       pull-requests: write # Needed to post review comments.
       issues: write        # Needed to file follow-up issues from a review.
       actions: read        # Needed to read CI check results on the PR.
+      id-token: write      # Required by claude-code-action for internal token management.
     steps:
       - name: Find code snapshot
         id: snapshot


### PR DESCRIPTION
## Summary

- `claude-code-action` requires `id-token: write` for internal OIDC token management, even when `anthropic_api_key` is provided directly
- This was removed during security hardening but causes the action to fail with: _Could not fetch an OIDC token_
- Added back to both `claude-issue` and `claude-pr` jobs

## Security note

Exfiltration risk is low: `claude-pr` has no `Bash`/`Edit`/`Write` tools, and `WebFetch` is domain-restricted in both jobs, so Claude cannot execute code or make outbound requests to exfiltrate the OIDC token.

## Test plan

- [ ] Trigger `@claude` on an issue comment and confirm the workflow completes without OIDC error
- [ ] Trigger `@claude` on a PR comment and confirm the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)