### PR TITLE
fix claude workflow: id-token and git init for artifact approach

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -129,6 +129,19 @@ jobs:
           run-id: ${{ steps.snapshot.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Initialize git repo for claude-code-action
+        run: |
+          # claude-code-action internally runs git fetch to resolve PR context,
+          # which requires a git repo with a configured remote. We initialize one
+          # from the artifact files and point the remote at the base repo so the
+          # fetch succeeds without touching the fork.
+          git init
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git add -A
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git commit -m "snapshot"
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Two fixes needed after merging the fork-safe rewrite (#329):

- **`id-token: write`** — `claude-code-action` requires this for internal OIDC token management even when `anthropic_api_key` is provided directly. Removing it causes: _Could not fetch an OIDC token_
- **git repo initialization** — the action internally runs `git fetch origin pull/<N>/head` to resolve PR context. The artifact-only working directory has no `.git`, so this fails. We initialize a repo from the artifact files and point the remote at the base repo so the fetch succeeds without checking out fork code.

## Security note

The git remote points to `codeforpdx/tenantfirstaid`, not the fork — the fetch pulls from the base repo. The working tree files still come from the artifact (captured by the unprivileged snapshot job), so the security model is preserved.

## Test plan

- [ ] Trigger `@claude` on a PR comment and confirm the workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)