### PR TITLE
Bug fix: running evaluation script didn't load environment

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -66,6 +66,7 @@ backend/
 |   ├── langchain_chat_manager.py       # Per-session agent wrapper with streaming support
 |   ├── langchain_tools.py              # LangChain Agent tools (i.e. RAG retriever)
 |   ├── google_auth.py                  # GCP credential loading (inline JSON or file path)
+|   ├── logger.py                       # Project-wide logging setup (colorized stderr handler, `configure_logging()` entrypoint hook)
 |   ├── system_prompt.md                # System prompt (editable without Python knowledge)
 |   ├── letter_template.md              # Letter template (editable without Python knowledge)
 │   ├── feedback.py                     # Message feedback logic and email integration
@@ -373,6 +374,12 @@ Each chunk is a serialized `ResponseChunk` (`text`, `reasoning`, `letter`, or `d
 - **Google Gemini 2.5 Pro**: Large language model
 - **Vertex AI RAG**: Document retrieval system
 - **Google Cloud AI Platform**: Managed AI services
+
+### Configuration and Logging
+
+Environment variables are loaded once, at `constants.py` import time, from an absolute path (`backend/.env`). This makes the load order independent of the current working directory and avoids the duplicate-load pattern that previously lived in `app.py`. If the `.env` file is missing the module emits a warning and falls back to the ambient environment, which is the normal case in deployed environments where secrets come from systemd rather than a file.
+
+Logging is centralized in `logger.py`. Entrypoints (`app.py`, `run_langsmith_evaluation.py`) call `configure_logging()` once to install a single stderr handler with a shared format; level defaults to `DEBUG` when `ENV=dev` and `INFO` otherwise. The formatter colorizes `WARNING`/`ERROR`/`CRITICAL` level names only when stderr is a TTY, so log files and CI captures stay free of ANSI escapes. `configure_logging()` is idempotent — repeated imports under pytest or gunicorn workers do not double-install handlers. For the narrow case where `constants.py` needs to emit a formatted warning during import (before any entrypoint has run), `temporary_formatted_handler()` attaches the project formatter to a single logger for the duration of a `with` block.
 
 ### Endpoints
 

--- a/backend/evaluate/run_langsmith_evaluation.py
+++ b/backend/evaluate/run_langsmith_evaluation.py
@@ -24,6 +24,10 @@ from evaluate.results_display import ScenarioResult, print_consistency_stats
 from tenantfirstaid.constants import LANGSMITH_API_KEY, SINGLETON
 from tenantfirstaid.langchain_chat_manager import LangChainChatManager
 from tenantfirstaid.location import OregonCity, UsaState
+from tenantfirstaid.logger import configure_logging
+
+# Configure logging after constants import so ENV from .env is honored.
+configure_logging()
 
 # Suppress the noisy additionalProperties warning from langchain_google_vertexai
 # https://github.com/langchain-ai/langchain-google/issues/1038#issuecomment-3707773510

--- a/backend/evaluate/run_langsmith_evaluation.py
+++ b/backend/evaluate/run_langsmith_evaluation.py
@@ -5,7 +5,6 @@ automated quality evaluation.
 """
 
 import argparse
-import logging
 from typing import Any, Dict, List, Optional
 
 from langchain_core.messages import HumanMessage
@@ -25,13 +24,6 @@ from tenantfirstaid.constants import LANGSMITH_API_KEY, SINGLETON
 from tenantfirstaid.langchain_chat_manager import LangChainChatManager
 from tenantfirstaid.location import OregonCity, UsaState
 from tenantfirstaid.logger import configure_logging
-
-# Configure logging after constants import so ENV from .env is honored.
-configure_logging()
-
-# Suppress the noisy additionalProperties warning from langchain_google_vertexai
-# https://github.com/langchain-ai/langchain-google/issues/1038#issuecomment-3707773510
-logging.getLogger("langchain_google_vertexai.functions_utils").setLevel(logging.ERROR)
 
 
 def agent_wrapper(inputs) -> Dict[str, str]:
@@ -204,6 +196,17 @@ def run_evaluation(
 
 
 def main() -> None:
+    import logging
+
+    # Configure logging after constants was imported above so ENV from .env is honored.
+    configure_logging()
+
+    # Suppress the noisy additionalProperties warning from langchain_google_vertexai.
+    # https://github.com/langchain-ai/langchain-google/issues/1038#issuecomment-3707773510
+    logging.getLogger("langchain_google_vertexai.functions_utils").setLevel(
+        logging.ERROR
+    )
+
     parser = argparse.ArgumentParser(
         description="Run LangSmith evaluation",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/backend/tenantfirstaid/app.py
+++ b/backend/tenantfirstaid/app.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 from flask import Flask
 from flask_cors import CORS
@@ -7,13 +6,13 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_mailman import Mail
 
-if Path(".env").exists():
-    from dotenv import load_dotenv
-
-    load_dotenv(override=True)
-
+# .chat → constants loads .env via an absolute path; do not re-load here.
 from .chat import ChatView
 from .feedback import send_feedback
+from .logger import configure_logging
+
+# Configure logging after .chat (→ constants → .env load) so ENV from .env is honored.
+configure_logging()
 
 app = Flask(__name__)
 

--- a/backend/tenantfirstaid/app.py
+++ b/backend/tenantfirstaid/app.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from pathlib import Path
 
@@ -50,12 +49,6 @@ app.config["MAIL_USE_TLS"] = True
 app.config["MAIL_USERNAME"] = os.getenv("SENDER_EMAIL")
 app.config["MAIL_PASSWORD"] = os.getenv("APP_PASSWORD")
 app.config["MAIL_DEFAULT_SENDER"] = os.getenv("SENDER_EMAIL")
-
-# Logging configuration
-logging.basicConfig(
-    level=logging.DEBUG if os.getenv("ENV") == "dev" else logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-)
 
 mail = Mail(app)
 

--- a/backend/tenantfirstaid/constants.py
+++ b/backend/tenantfirstaid/constants.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from collections.abc import Mapping
 from enum import StrEnum, auto
 from pathlib import Path
@@ -7,6 +8,62 @@ from typing import Final, Optional, cast
 
 from dotenv import load_dotenv
 from langchain_google_genai import HarmBlockThreshold, HarmCategory
+
+
+class _ColoredLevelFormatter(logging.Formatter):
+    """Formatter that colorizes the level name when emitting to a TTY.
+
+    Colors are only applied when the handler's stream is a TTY, so log files
+    and CI captures stay free of ANSI escapes.
+    """
+
+    _LEVEL_COLORS = {
+        logging.WARNING: "\033[33m",  # yellow
+        logging.ERROR: "\033[31m",  # red
+        logging.CRITICAL: "\033[1;31m",  # bold red
+    }
+    _RESET = "\033[0m"
+
+    def __init__(self, fmt: str, use_color: bool) -> None:
+        super().__init__(fmt)
+        self._use_color = use_color
+
+    def format(self, record: logging.LogRecord) -> str:
+        if self._use_color and record.levelno in self._LEVEL_COLORS:
+            original = record.levelname
+            record.levelname = (
+                f"{self._LEVEL_COLORS[record.levelno]}{original}{self._RESET}"
+            )
+            try:
+                return super().format(record)
+            finally:
+                record.levelname = original
+        return super().format(record)
+
+
+def _configure_root_logger() -> None:
+    """Install a single stderr handler with a consistent colorized format.
+
+    Done at import time so any module logging through `logging.getLogger(...)`
+    inherits the same look. We only attach if no handler is already present,
+    to avoid double-logging when something else (e.g. pytest, gunicorn) has
+    already configured logging.
+    """
+    root = logging.getLogger()
+    if root.handlers:
+        return
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(
+        _ColoredLevelFormatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            use_color=sys.stderr.isatty(),
+        )
+    )
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG if os.getenv("ENV") == "dev" else logging.INFO)
+
+
+_configure_root_logger()
 
 logger = logging.getLogger(__name__)
 

--- a/backend/tenantfirstaid/constants.py
+++ b/backend/tenantfirstaid/constants.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections.abc import Mapping
 from enum import StrEnum, auto
@@ -6,6 +7,8 @@ from typing import Final, Optional, cast
 
 from dotenv import load_dotenv
 from langchain_google_genai import HarmBlockThreshold, HarmCategory
+
+logger = logging.getLogger(__name__)
 
 _DATASTORE_PREFIX = "VERTEX_AI_DATASTORE_"
 
@@ -87,9 +90,14 @@ class _GoogEnvAndPolicy:
         3. check that the slotted attributes are not None
         """
         # read .env at object creation time
-        path_to_env = Path(__file__).parent / "../.env"
+        path_to_env: Final[Path] = Path(__file__).parent.parent / ".env"
         if path_to_env.exists():
-            load_dotenv(override=True)
+            load_dotenv(dotenv_path=path_to_env, override=True)
+        else:
+            logger.warning(
+                "No .env file found at %s, proceeding with existing environment variables.",
+                path_to_env,
+            )
 
         # Assign & Check slot attributes for required environment variables.
         # Note: assign explicitly since typecheckers do not understand slotted attributes

--- a/backend/tenantfirstaid/constants.py
+++ b/backend/tenantfirstaid/constants.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 from collections.abc import Mapping
 from enum import StrEnum, auto
 from pathlib import Path
@@ -9,61 +8,7 @@ from typing import Final, Optional, cast
 from dotenv import load_dotenv
 from langchain_google_genai import HarmBlockThreshold, HarmCategory
 
-
-class _ColoredLevelFormatter(logging.Formatter):
-    """Formatter that colorizes the level name when emitting to a TTY.
-
-    Colors are only applied when the handler's stream is a TTY, so log files
-    and CI captures stay free of ANSI escapes.
-    """
-
-    _LEVEL_COLORS = {
-        logging.WARNING: "\033[33m",  # yellow
-        logging.ERROR: "\033[31m",  # red
-        logging.CRITICAL: "\033[1;31m",  # bold red
-    }
-    _RESET = "\033[0m"
-
-    def __init__(self, fmt: str, use_color: bool) -> None:
-        super().__init__(fmt)
-        self._use_color = use_color
-
-    def format(self, record: logging.LogRecord) -> str:
-        if self._use_color and record.levelno in self._LEVEL_COLORS:
-            original = record.levelname
-            record.levelname = (
-                f"{self._LEVEL_COLORS[record.levelno]}{original}{self._RESET}"
-            )
-            try:
-                return super().format(record)
-            finally:
-                record.levelname = original
-        return super().format(record)
-
-
-def _configure_root_logger() -> None:
-    """Install a single stderr handler with a consistent colorized format.
-
-    Done at import time so any module logging through `logging.getLogger(...)`
-    inherits the same look. We only attach if no handler is already present,
-    to avoid double-logging when something else (e.g. pytest, gunicorn) has
-    already configured logging.
-    """
-    root = logging.getLogger()
-    if root.handlers:
-        return
-    handler = logging.StreamHandler(stream=sys.stderr)
-    handler.setFormatter(
-        _ColoredLevelFormatter(
-            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-            use_color=sys.stderr.isatty(),
-        )
-    )
-    root.addHandler(handler)
-    root.setLevel(logging.DEBUG if os.getenv("ENV") == "dev" else logging.INFO)
-
-
-_configure_root_logger()
+from .logger import temporary_formatted_handler
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +92,7 @@ class _GoogEnvAndPolicy:
         3. check that the slotted attributes are not None
         """
         # read .env at object creation time
-        path_to_env: Final[Path] = Path(__file__).parent.parent / ".env"
+        path_to_env = Path(__file__).parent.parent / ".env"
         if path_to_env.exists():
             load_dotenv(dotenv_path=path_to_env, override=True)
         else:
@@ -219,7 +164,10 @@ GEMINI_THINKING_BUDGET_DYNAMIC: Final = -1
 
 # Module singleton
 # TODO: rename to VERTEX_CONFIG?
-SINGLETON: Final = _GoogEnvAndPolicy()
+# Use the project log format for the "no .env" warning emitted during __init__,
+# even though entrypoints have not yet called configure_logging().
+with temporary_formatted_handler(logger):
+    SINGLETON: Final = _GoogEnvAndPolicy()
 
 LANGSMITH_API_KEY: Final = os.getenv("LANGSMITH_API_KEY")
 

--- a/backend/tenantfirstaid/constants.py
+++ b/backend/tenantfirstaid/constants.py
@@ -91,7 +91,7 @@ class _GoogEnvAndPolicy:
         2. explicitly set each slotted attribute
         3. check that the slotted attributes are not None
         """
-        # read .env at object creation time
+        # Read .env at object creation time.
         path_to_env = Path(__file__).parent.parent / ".env"
         if path_to_env.exists():
             load_dotenv(dotenv_path=path_to_env, override=True)

--- a/backend/tenantfirstaid/langchain_chat_manager.py
+++ b/backend/tenantfirstaid/langchain_chat_manager.py
@@ -5,7 +5,6 @@ agent graph with per-session location context and streaming support.
 """
 
 import logging
-import sys
 from typing import Any, Dict, Generator, List, Optional, cast
 
 from langchain_core.messages import (
@@ -34,13 +33,7 @@ class LangChainChatManager:
     def __init__(self) -> None:
         """Initialize the LangChain chat manager."""
 
-        # configure logging
-        logging.basicConfig(
-            level=logging.WARNING,
-            stream=sys.stdout,
-            format="%(levelname)s: %(message)s (%(filename)s:%(lineno)d)",
-        )
-        self.logger = logging.getLogger("LangChainChatManager")
+        self.logger = logging.getLogger(__name__)
 
         # defer agent instantiation until 'generate_stream_response'
         self.agent = None

--- a/backend/tenantfirstaid/langchain_chat_manager.py
+++ b/backend/tenantfirstaid/langchain_chat_manager.py
@@ -35,7 +35,7 @@ class LangChainChatManager:
 
         self.logger = logging.getLogger(__name__)
 
-        # defer agent instantiation until 'generate_stream_response'
+        # Defer agent instantiation until 'generate_stream_response'.
         self.agent = None
         self.system_prompt: Optional[SystemMessage] = None
 

--- a/backend/tenantfirstaid/logger.py
+++ b/backend/tenantfirstaid/logger.py
@@ -8,15 +8,17 @@ a single stderr handler with the colorized format used across the codebase.
 import logging
 import os
 import sys
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Iterator
+
+_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 
 
 class _ColoredLevelFormatter(logging.Formatter):
     """Formatter that colorizes the level name when emitting to a TTY.
 
-    Colors are only applied when the handler's stream is a TTY, so log files
-    and CI captures stay free of ANSI escapes.
+    The TTY check happens once at construction (based on `sys.stderr`), so
+    log files and CI captures stay free of ANSI escapes.
     """
 
     _LEVEL_COLORS = {
@@ -26,9 +28,9 @@ class _ColoredLevelFormatter(logging.Formatter):
     }
     _RESET = "\033[0m"
 
-    def __init__(self, fmt: str, use_color: bool) -> None:
-        super().__init__(fmt)
-        self._use_color = use_color
+    def __init__(self) -> None:
+        super().__init__(_FORMAT)
+        self._use_color = sys.stderr.isatty()
 
     def format(self, record: logging.LogRecord) -> str:
         if self._use_color and record.levelno in self._LEVEL_COLORS:
@@ -43,8 +45,15 @@ class _ColoredLevelFormatter(logging.Formatter):
         return super().format(record)
 
 
+def _make_stderr_handler() -> logging.StreamHandler:
+    """Build a stderr handler wired with the project formatter."""
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(_ColoredLevelFormatter())
+    return handler
+
+
 def configure_logging() -> None:
-    """Install a single stderr handler with a consistent colorized format.
+    """Install a single stderr handler with the project formatter.
 
     Idempotent: if the root logger already has a handler, this is a no-op so
     we don't double-log under pytest, gunicorn, or repeated imports.
@@ -52,14 +61,7 @@ def configure_logging() -> None:
     root = logging.getLogger()
     if root.handlers:
         return
-    handler = logging.StreamHandler(stream=sys.stderr)
-    handler.setFormatter(
-        _ColoredLevelFormatter(
-            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-            use_color=sys.stderr.isatty(),
-        )
-    )
-    root.addHandler(handler)
+    root.addHandler(_make_stderr_handler())
     root.setLevel(logging.DEBUG if os.getenv("ENV") == "dev" else logging.INFO)
 
 
@@ -72,13 +74,7 @@ def temporary_formatted_handler(logger: logging.Logger) -> Iterator[None]:
     appear in the project format. Propagation is suspended inside the block
     so the message is not also emitted via Python's `lastResort` handler.
     """
-    handler = logging.StreamHandler(stream=sys.stderr)
-    handler.setFormatter(
-        _ColoredLevelFormatter(
-            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-            use_color=sys.stderr.isatty(),
-        )
-    )
+    handler = _make_stderr_handler()
     previous_propagate = logger.propagate
     logger.addHandler(handler)
     logger.propagate = False

--- a/backend/tenantfirstaid/logger.py
+++ b/backend/tenantfirstaid/logger.py
@@ -1,0 +1,89 @@
+"""Project-wide logging configuration.
+
+Importing this module is side-effect-free; call `configure_logging()` from an
+entrypoint (e.g. `constants.py` at first import, or a CLI script) to install
+a single stderr handler with the colorized format used across the codebase.
+"""
+
+import logging
+import os
+import sys
+from contextlib import contextmanager
+from typing import Iterator
+
+
+class _ColoredLevelFormatter(logging.Formatter):
+    """Formatter that colorizes the level name when emitting to a TTY.
+
+    Colors are only applied when the handler's stream is a TTY, so log files
+    and CI captures stay free of ANSI escapes.
+    """
+
+    _LEVEL_COLORS = {
+        logging.WARNING: "\033[33m",  # Yellow.
+        logging.ERROR: "\033[31m",  # Red.
+        logging.CRITICAL: "\033[1;31m",  # Bold red.
+    }
+    _RESET = "\033[0m"
+
+    def __init__(self, fmt: str, use_color: bool) -> None:
+        super().__init__(fmt)
+        self._use_color = use_color
+
+    def format(self, record: logging.LogRecord) -> str:
+        if self._use_color and record.levelno in self._LEVEL_COLORS:
+            original = record.levelname
+            record.levelname = (
+                f"{self._LEVEL_COLORS[record.levelno]}{original}{self._RESET}"
+            )
+            try:
+                return super().format(record)
+            finally:
+                record.levelname = original
+        return super().format(record)
+
+
+def configure_logging() -> None:
+    """Install a single stderr handler with a consistent colorized format.
+
+    Idempotent: if the root logger already has a handler, this is a no-op so
+    we don't double-log under pytest, gunicorn, or repeated imports.
+    """
+    root = logging.getLogger()
+    if root.handlers:
+        return
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(
+        _ColoredLevelFormatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            use_color=sys.stderr.isatty(),
+        )
+    )
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG if os.getenv("ENV") == "dev" else logging.INFO)
+
+
+@contextmanager
+def temporary_formatted_handler(logger: logging.Logger) -> Iterator[None]:
+    """Attach the project formatter to `logger` for the duration of the block.
+
+    Useful at module-import time when the root logger has not yet been
+    configured by an entrypoint, but a module wants its own warnings to
+    appear in the project format. Propagation is suspended inside the block
+    so the message is not also emitted via Python's `lastResort` handler.
+    """
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(
+        _ColoredLevelFormatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            use_color=sys.stderr.isatty(),
+        )
+    )
+    previous_propagate = logger.propagate
+    logger.addHandler(handler)
+    logger.propagate = False
+    try:
+        yield
+    finally:
+        logger.removeHandler(handler)
+        logger.propagate = previous_propagate

--- a/backend/tests/test_constants.py
+++ b/backend/tests/test_constants.py
@@ -3,6 +3,7 @@ ensure that only keys that should exist are readable
 ensure that symbols are read-only
 """
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -78,6 +79,13 @@ class TestStrtobool:
 
 
 class TestGoogEnvAndPolicy:
+    @pytest.fixture(autouse=True)
+    def _silence_missing_env_warning(self, caplog):
+        # These tests deliberately patch Path.exists -> False to exercise the
+        # "no .env, rely on ambient environment" path, which emits a warning.
+        # Suppress it so the test output stays clean.
+        caplog.set_level(logging.CRITICAL, logger="tenantfirstaid.constants")
+
     REQUIRED_ENV = {
         "MODEL_NAME": "gemini-2.5-pro",
         "VERTEX_AI_DATASTORE_LAWS": "test-datastore",

--- a/backend/tests/test_constants.py
+++ b/backend/tests/test_constants.py
@@ -4,6 +4,7 @@ ensure that symbols are read-only
 """
 
 import logging
+import re
 from unittest.mock import patch
 
 import pytest
@@ -79,18 +80,17 @@ class TestStrtobool:
 
 
 class TestGoogEnvAndPolicy:
-    @pytest.fixture(autouse=True)
-    def _no_env_file(self):
-        # Exercise the "no .env, rely on ambient environment" path for every
-        # test in this class, so each test can inject env vars via os.environ
-        # without a real .env file interfering.
+    @pytest.fixture
+    def no_env_file(self):
+        # Force the "no .env" code path so the test relies purely on the
+        # ambient os.environ injected by patch.dict.
         with patch("tenantfirstaid.constants.Path.exists", return_value=False):
             yield
 
-    @pytest.fixture(autouse=True)
-    def _silence_missing_env_warning(self, caplog):
-        # The "no .env" path emits a warning; suppress it by default so test
-        # output stays clean. Individual tests can override via caplog.set_level.
+    @pytest.fixture
+    def silence_missing_env_warning(self, caplog):
+        # The "no .env" path emits a warning; tests that don't want to assert
+        # on it can opt into this fixture to keep test output clean.
         caplog.set_level(logging.CRITICAL, logger="tenantfirstaid.constants")
 
     REQUIRED_ENV = {
@@ -102,21 +102,24 @@ class TestGoogEnvAndPolicy:
     }
 
     @patch.dict("os.environ", REQUIRED_ENV, clear=False)
-    def test_init_with_all_vars(self):
+    def test_init_with_all_vars(self, no_env_file, silence_missing_env_warning):
         singleton = _GoogEnvAndPolicy()
         assert singleton.MODEL_NAME == "gemini-2.5-pro"
         assert singleton.GOOGLE_CLOUD_PROJECT == "test-project"
         assert singleton.VERTEX_AI_DATASTORES["laws"] == "test-datastore"
 
     @pytest.mark.parametrize("missing_var", REQUIRED_ENV.keys())
-    def test_missing_required_var_raises(self, missing_var):
+    def test_missing_required_var_raises(
+        self, missing_var, no_env_file, silence_missing_env_warning
+    ):
         env = {k: v for k, v in self.REQUIRED_ENV.items() if k != missing_var}
         with patch.dict("os.environ", env, clear=True):
             with pytest.raises(ValueError, match="environment variable is not set"):
                 _GoogEnvAndPolicy()
 
-    def test_missing_env_file_emits_warning_with_resolved_path(self, caplog):
-        # Override the autouse silencer: we want to assert the warning.
+    def test_missing_env_file_emits_warning_with_resolved_path(
+        self, no_env_file, caplog
+    ):
         caplog.set_level(logging.WARNING, logger="tenantfirstaid.constants")
         with patch.dict("os.environ", self.REQUIRED_ENV, clear=False):
             _GoogEnvAndPolicy()
@@ -125,11 +128,11 @@ class TestGoogEnvAndPolicy:
         msg = warnings[-1].getMessage()
         assert "No .env file found" in msg
         # The resolved path is absolute and points at backend/.env.
-        assert msg.endswith(
-            "/backend/.env, proceeding with existing environment variables."
-        )
+        assert re.search(r"/backend/\.env, proceeding\b", msg)
 
-    def test_missing_laws_datastore_raises(self):
+    def test_missing_laws_datastore_raises(
+        self, no_env_file, silence_missing_env_warning
+    ):
         env = {
             **self.REQUIRED_ENV,
             "VERTEX_AI_DATASTORE_OREGONLAWHELP": "store-1",

--- a/backend/tests/test_constants.py
+++ b/backend/tests/test_constants.py
@@ -111,6 +111,21 @@ class TestGoogEnvAndPolicy:
                 _GoogEnvAndPolicy()
 
     @patch("tenantfirstaid.constants.Path.exists", return_value=False)
+    def test_missing_env_file_emits_warning_with_resolved_path(self, mock_path, caplog):
+        # Override the autouse silencer: we want to assert the warning.
+        caplog.set_level(logging.WARNING, logger="tenantfirstaid.constants")
+        with patch.dict("os.environ", self.REQUIRED_ENV, clear=False):
+            _GoogEnvAndPolicy()
+        warnings = [r for r in caplog.records if r.name == "tenantfirstaid.constants"]
+        assert warnings, "expected a warning when .env is missing"
+        msg = warnings[-1].getMessage()
+        assert "No .env file found" in msg
+        # The resolved path is absolute and points at backend/.env.
+        assert msg.endswith(
+            "/backend/.env, proceeding with existing environment variables."
+        )
+
+    @patch("tenantfirstaid.constants.Path.exists", return_value=False)
     def test_missing_laws_datastore_raises(self, mock_path):
         env = {
             **self.REQUIRED_ENV,

--- a/backend/tests/test_constants.py
+++ b/backend/tests/test_constants.py
@@ -80,10 +80,17 @@ class TestStrtobool:
 
 class TestGoogEnvAndPolicy:
     @pytest.fixture(autouse=True)
+    def _no_env_file(self):
+        # Exercise the "no .env, rely on ambient environment" path for every
+        # test in this class, so each test can inject env vars via os.environ
+        # without a real .env file interfering.
+        with patch("tenantfirstaid.constants.Path.exists", return_value=False):
+            yield
+
+    @pytest.fixture(autouse=True)
     def _silence_missing_env_warning(self, caplog):
-        # These tests deliberately patch Path.exists -> False to exercise the
-        # "no .env, rely on ambient environment" path, which emits a warning.
-        # Suppress it so the test output stays clean.
+        # The "no .env" path emits a warning; suppress it by default so test
+        # output stays clean. Individual tests can override via caplog.set_level.
         caplog.set_level(logging.CRITICAL, logger="tenantfirstaid.constants")
 
     REQUIRED_ENV = {
@@ -94,24 +101,21 @@ class TestGoogEnvAndPolicy:
         "GOOGLE_APPLICATION_CREDENTIALS": "/tmp/creds.json",
     }
 
-    @patch("tenantfirstaid.constants.Path.exists", return_value=False)
     @patch.dict("os.environ", REQUIRED_ENV, clear=False)
-    def test_init_with_all_vars(self, mock_path):
+    def test_init_with_all_vars(self):
         singleton = _GoogEnvAndPolicy()
         assert singleton.MODEL_NAME == "gemini-2.5-pro"
         assert singleton.GOOGLE_CLOUD_PROJECT == "test-project"
         assert singleton.VERTEX_AI_DATASTORES["laws"] == "test-datastore"
 
     @pytest.mark.parametrize("missing_var", REQUIRED_ENV.keys())
-    @patch("tenantfirstaid.constants.Path.exists", return_value=False)
-    def test_missing_required_var_raises(self, mock_path, missing_var):
+    def test_missing_required_var_raises(self, missing_var):
         env = {k: v for k, v in self.REQUIRED_ENV.items() if k != missing_var}
         with patch.dict("os.environ", env, clear=True):
             with pytest.raises(ValueError, match="environment variable is not set"):
                 _GoogEnvAndPolicy()
 
-    @patch("tenantfirstaid.constants.Path.exists", return_value=False)
-    def test_missing_env_file_emits_warning_with_resolved_path(self, mock_path, caplog):
+    def test_missing_env_file_emits_warning_with_resolved_path(self, caplog):
         # Override the autouse silencer: we want to assert the warning.
         caplog.set_level(logging.WARNING, logger="tenantfirstaid.constants")
         with patch.dict("os.environ", self.REQUIRED_ENV, clear=False):
@@ -125,8 +129,7 @@ class TestGoogEnvAndPolicy:
             "/backend/.env, proceeding with existing environment variables."
         )
 
-    @patch("tenantfirstaid.constants.Path.exists", return_value=False)
-    def test_missing_laws_datastore_raises(self, mock_path):
+    def test_missing_laws_datastore_raises(self):
         env = {
             **self.REQUIRED_ENV,
             "VERTEX_AI_DATASTORE_OREGONLAWHELP": "store-1",

--- a/backend/tests/test_logger.py
+++ b/backend/tests/test_logger.py
@@ -2,11 +2,32 @@
 
 import ast
 import logging
-import uuid
 from pathlib import Path
+from typing import Iterator
+
+import pytest
 
 from tenantfirstaid import logger as logger_module
 from tenantfirstaid.logger import temporary_formatted_handler
+
+
+@pytest.fixture
+def isolated_logger(request) -> Iterator[logging.Logger]:
+    """Yield a logger whose name is unique to the test, then tear it down.
+
+    Python's `logging.getLogger(name)` interns logger objects in
+    `Manager.loggerDict` for the life of the process; without explicit
+    cleanup, every test would leak a named logger.
+    """
+    name = f"test.tfa.{request.node.name}"
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.propagate = True
+    try:
+        yield logger
+    finally:
+        logger.handlers.clear()
+        logging.Logger.manager.loggerDict.pop(name, None)
 
 
 def test_logger_module_does_not_import_constants():
@@ -30,74 +51,66 @@ def test_logger_module_does_not_import_constants():
     )
 
 
-def _fresh_logger() -> logging.Logger:
-    """Return an isolated logger with a unique name and no handlers."""
-    logger = logging.getLogger(f"test.tfa.{uuid.uuid4()}")
-    logger.handlers.clear()
-    logger.propagate = True
-    return logger
-
-
 class TestTemporaryFormattedHandler:
-    def test_attaches_handler_inside_block(self):
-        logger = _fresh_logger()
-        pre = list(logger.handlers)
-        with temporary_formatted_handler(logger):
-            assert len(logger.handlers) == len(pre) + 1
-            assert isinstance(logger.handlers[-1], logging.StreamHandler)
-            assert logger.handlers[-1].formatter is not None
+    def test_attaches_handler_inside_block(self, isolated_logger):
+        pre = list(isolated_logger.handlers)
+        with temporary_formatted_handler(isolated_logger):
+            assert len(isolated_logger.handlers) == len(pre) + 1
+            assert isinstance(isolated_logger.handlers[-1], logging.StreamHandler)
+            assert isolated_logger.handlers[-1].formatter is not None
 
-    def test_suspends_propagation_inside_block(self):
-        logger = _fresh_logger()
-        logger.propagate = True
-        with temporary_formatted_handler(logger):
-            assert logger.propagate is False
+    def test_suspends_propagation_inside_block(self, isolated_logger):
+        isolated_logger.propagate = True
+        with temporary_formatted_handler(isolated_logger):
+            assert isolated_logger.propagate is False
 
-    def test_restores_state_on_exit(self):
-        logger = _fresh_logger()
-        logger.propagate = True
-        pre_handlers = list(logger.handlers)
-        with temporary_formatted_handler(logger):
+    def test_restores_state_on_exit(self, isolated_logger):
+        isolated_logger.propagate = True
+        pre_handlers = list(isolated_logger.handlers)
+        with temporary_formatted_handler(isolated_logger):
             pass
-        assert logger.handlers == pre_handlers
-        assert logger.propagate is True
+        assert isolated_logger.handlers == pre_handlers
+        assert isolated_logger.propagate is True
 
-    def test_restores_state_on_exception(self):
-        logger = _fresh_logger()
-        logger.propagate = True
-        pre_handlers = list(logger.handlers)
+    def test_restores_state_on_exception(self, isolated_logger):
+        isolated_logger.propagate = True
+        pre_handlers = list(isolated_logger.handlers)
         try:
-            with temporary_formatted_handler(logger):
+            with temporary_formatted_handler(isolated_logger):
                 raise RuntimeError("boom")
         except RuntimeError:
             pass
-        assert logger.handlers == pre_handlers
-        assert logger.propagate is True
+        assert isolated_logger.handlers == pre_handlers
+        assert isolated_logger.propagate is True
 
-    def test_preserves_prior_propagate_setting(self):
+    def test_preserves_prior_propagate_setting(self, isolated_logger):
         # When the caller has already disabled propagation, the context manager
         # must leave it disabled on exit (not flip it back to True).
-        logger = _fresh_logger()
-        logger.propagate = False
-        with temporary_formatted_handler(logger):
-            assert logger.propagate is False
-        assert logger.propagate is False
+        isolated_logger.propagate = False
+        with temporary_formatted_handler(isolated_logger):
+            assert isolated_logger.propagate is False
+        assert isolated_logger.propagate is False
 
-    def test_emits_record_through_temporary_handler(self):
+    def test_emits_record_through_temporary_handler(self, isolated_logger):
         # Sanity check that the attached handler actually formats the record
         # using the project format (timestamp + bracketed level + logger name).
+        # Force isatty()->False so the assertion is deterministic regardless
+        # of how the test is invoked (terminal vs. CI capture).
         import io
+        from unittest.mock import patch
 
-        logger = _fresh_logger()
-        logger.setLevel(logging.WARNING)
-        with temporary_formatted_handler(logger):
-            # Redirect the handler's stream to a buffer so we can read the output.
-            handler = logger.handlers[-1]
-            buf = io.StringIO()
-            assert isinstance(handler, logging.StreamHandler)
-            handler.stream = buf
-            logger.warning("hello %s", "world")
+        isolated_logger.setLevel(logging.WARNING)
+        with patch("sys.stderr") as mock_stderr:
+            mock_stderr.isatty.return_value = False
+            with temporary_formatted_handler(isolated_logger):
+                # Redirect the handler's stream to a buffer so we can read the output.
+                handler = isolated_logger.handlers[-1]
+                buf = io.StringIO()
+                assert isinstance(handler, logging.StreamHandler)
+                handler.stream = buf
+                isolated_logger.warning("hello %s", "world")
         out = buf.getvalue()
         assert "[WARNING]" in out
-        assert logger.name in out
+        assert "\033[" not in out, "expected no ANSI escapes when isatty=False"
+        assert isolated_logger.name in out
         assert "hello world" in out

--- a/backend/tests/test_logger.py
+++ b/backend/tests/test_logger.py
@@ -100,8 +100,7 @@ class TestTemporaryFormattedHandler:
         from unittest.mock import patch
 
         isolated_logger.setLevel(logging.WARNING)
-        with patch("sys.stderr") as mock_stderr:
-            mock_stderr.isatty.return_value = False
+        with patch("sys.stderr.isatty", return_value=False):
             with temporary_formatted_handler(isolated_logger):
                 # Redirect the handler's stream to a buffer so we can read the output.
                 handler = isolated_logger.handlers[-1]

--- a/backend/tests/test_logger.py
+++ b/backend/tests/test_logger.py
@@ -1,0 +1,103 @@
+"""Unit tests for tenantfirstaid.logger helpers."""
+
+import ast
+import logging
+import uuid
+from pathlib import Path
+
+from tenantfirstaid import logger as logger_module
+from tenantfirstaid.logger import temporary_formatted_handler
+
+
+def test_logger_module_does_not_import_constants():
+    # logger.py must stay free of project imports so that constants.py
+    # (which imports logger) can't create an import cycle.
+    source = Path(logger_module.__file__).read_text()
+    tree = ast.parse(source)
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("tenantfirstaid"):
+                    offenders.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            # Catches both absolute (`from tenantfirstaid.X import Y`) and
+            # relative (`from .X import Y`) forms.
+            if node.level > 0 or (node.module or "").startswith("tenantfirstaid"):
+                offenders.append(node.module or f"(relative level {node.level})")
+    assert not offenders, (
+        f"tenantfirstaid.logger must not import from the project; found: {offenders}"
+    )
+
+
+def _fresh_logger() -> logging.Logger:
+    """Return an isolated logger with a unique name and no handlers."""
+    logger = logging.getLogger(f"test.tfa.{uuid.uuid4()}")
+    logger.handlers.clear()
+    logger.propagate = True
+    return logger
+
+
+class TestTemporaryFormattedHandler:
+    def test_attaches_handler_inside_block(self):
+        logger = _fresh_logger()
+        pre = list(logger.handlers)
+        with temporary_formatted_handler(logger):
+            assert len(logger.handlers) == len(pre) + 1
+            assert isinstance(logger.handlers[-1], logging.StreamHandler)
+            assert logger.handlers[-1].formatter is not None
+
+    def test_suspends_propagation_inside_block(self):
+        logger = _fresh_logger()
+        logger.propagate = True
+        with temporary_formatted_handler(logger):
+            assert logger.propagate is False
+
+    def test_restores_state_on_exit(self):
+        logger = _fresh_logger()
+        logger.propagate = True
+        pre_handlers = list(logger.handlers)
+        with temporary_formatted_handler(logger):
+            pass
+        assert logger.handlers == pre_handlers
+        assert logger.propagate is True
+
+    def test_restores_state_on_exception(self):
+        logger = _fresh_logger()
+        logger.propagate = True
+        pre_handlers = list(logger.handlers)
+        try:
+            with temporary_formatted_handler(logger):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        assert logger.handlers == pre_handlers
+        assert logger.propagate is True
+
+    def test_preserves_prior_propagate_setting(self):
+        # When the caller has already disabled propagation, the context manager
+        # must leave it disabled on exit (not flip it back to True).
+        logger = _fresh_logger()
+        logger.propagate = False
+        with temporary_formatted_handler(logger):
+            assert logger.propagate is False
+        assert logger.propagate is False
+
+    def test_emits_record_through_temporary_handler(self):
+        # Sanity check that the attached handler actually formats the record
+        # using the project format (timestamp + bracketed level + logger name).
+        import io
+
+        logger = _fresh_logger()
+        logger.setLevel(logging.WARNING)
+        with temporary_formatted_handler(logger):
+            # Redirect the handler's stream to a buffer so we can read the output.
+            handler = logger.handlers[-1]
+            buf = io.StringIO()
+            assert isinstance(handler, logging.StreamHandler)
+            handler.stream = buf
+            logger.warning("hello %s", "world")
+        out = buf.getvalue()
+        assert "[WARNING]" in out
+        assert logger.name in out
+        assert "hello world" in out


### PR DESCRIPTION
…how deployments work) when .env file is not found

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Infrastructure
- [ ] Maintenance

## Description

The evaluation script imports `constants.py` which is where all the environment variables are supposed to be loaded.  Due to quirks in invocation and how the `.env` path was resolved, it did not work consistently and looked like a user-specific issue when it was an invocation-specific issue.

This also adds a more descriptive warning when `.env` is not found.

And this refactors the logger for consistent formatting across files.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note on the devices and browsers this has been tested on, as well as any relevant images for UI changes._


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## Documentation

- [x] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?
