### PR TITLE
Feature sidebar toggle

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -472,6 +472,7 @@ frontend/
 │   │   │   ├── BeaverIcon.tsx      # Oregon-themed icon
 │   │   │   ├── DisclaimerLayout.tsx  # Layout for disclaimer components
 │   │   │   ├── FeatureSnippet.tsx  # Features and references component
+│   │   │   ├── FeaturesPanel.tsx   # Collapsible Features sidebar
 │   │   │   ├── MessageContainer.tsx  # Layout for main UI component
 │   │   │   ├── PageSection.tsx     # Layout static page sections component
 │   │   │   ├── SafeMarkdown.tsx    # Safe markdown renderer
@@ -485,6 +486,7 @@ frontend/
 │   └── tests/                     # Testing suite
 │   │   ├── components/            # Component testing
 │   │   │   ├── About.test.tsx     # About component testing
+│   │   │   ├── FeaturesPanel.test.tsx # FeaturesPanel toggle testing
 │   │   │   ├── ChatDisclaimer.test.tsx # ChatDisclaimer component testing
 │   │   │   ├── HousingContext.test.tsx # HousingContext component testing
 │   │   │   ├── InitializationForm.test.tsx # InitializationForm component testing

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -10,6 +10,8 @@ import MobilePanel from "./shared/components/MobilePanel";
 import { Navigate, useParams } from "react-router-dom";
 import { classifyStateSegment } from "./shared/utils/jurisdiction";
 import { DEFAULT_JURISDICTION } from "./shared/constants/jurisdictions";
+import { useState } from "react";
+import ChevronRight from "./shared/components/ChevronRight";
 import clsx from "clsx";
 
 /**
@@ -44,9 +46,10 @@ function ChatView() {
   const { addMessage, messages, setMessages } = useMessages();
   const isOngoing = messages.length > 0;
   const { letterContent } = useLetterContent(messages);
+  const [featuresOpen, setFeaturesOpen] = useState(true);
 
   return (
-    <div className="min-h-full lg:h-full w-full flex flex-col lg:flex-row transition-all duration-300">
+    <div className="min-h-full lg:h-full w-full flex flex-col lg:flex-row transition-all duration-300 lg:relative lg:bg-paper-background">
       <div className="flex-1 lg:flex-none lg:my-0 w-full lg:w-3/5 flex lg:order-2">
         <MessageContainer isOngoing={isOngoing} letterContent={letterContent}>
           <div
@@ -80,21 +83,50 @@ function ChatView() {
           </div>
         </MobilePanel>
       </div>
+      <button
+        type="button"
+        onClick={() => setFeaturesOpen(!featuresOpen)}
+        className={clsx(
+          "hidden lg:flex items-center justify-center", 
+          "absolute top-4 z-10",
+          "w-6 h-6 bg-paper-background border border-gray-light rounded-l-md",
+          "transition-[right] duration-300 ease-in-out",
+          featuresOpen ? "right-[20%]" : "right-0",
+        )}
+        >
+          <span
+            className={clsx(
+              "transition-transform duration-300",
+              featuresOpen ? "rotate-0" : "rotate-180",
+            )}
+          >
+            <ChevronRight size={14} />
+          </span>
+        </button>
       <div
         className={clsx(
           "flex flex-col w-full bg-paper-background",
           "border-b lg:border-b-0 border-gray-light",
-          "lg:order-3 lg:my-0 lg:w-1/5 lg:border-l",
+          "lg:order-3 lg:my-0 lg:ml-auto",
+          "lg:transition-[width] lg:duration-300 lg:ease-in-out overflow-hidden",
+          featuresOpen ? "lg:w-1/5" : "lg:w-0",
           "[@media(max-height:800px)]:my-0 [@media(max-height:800px)]:self-stretch [@media(max-height:800px)]:overflow-hidden",
         )}
-      >
-        <MobilePanel title="Features">
-          <div className="flex flex-col flex-1 min-h-0 lg:overflow-y-auto [@media(max-height:800px)]:overflow-y-auto">
-            <FeatureSnippet />
+      >        
+        <div className={clsx(
+          "flex-1 flex flex-col min-w-0 lg:border-l border-gray-light",
+          "lg:transition-opacity lg:duration-300",
+          "lg:w-[20vw]",
+          featuresOpen ? "lg:opacity-100" : "lg:opacity-0 pointer-events-none",
+        )}>
+          <MobilePanel title="Features">
+            <div className="flex flex-col flex-1 min-h-0 lg:overflow-y-auto [@media(max-height:800px)]:overflow-y-auto">
+              <FeatureSnippet />
+            </div>
+          </MobilePanel>
+          <div className="p-4 [@media(min-width:1024px)_and_(min-height:801px)]:mt-auto">
+            <ChatDisclaimer isOngoing={isOngoing} />
           </div>
-        </MobilePanel>
-        <div className="p-4 [@media(min-width:1024px)_and_(min-height:801px)]:mt-auto">
-          <ChatDisclaimer isOngoing={isOngoing} />
         </div>
       </div>
     </div>

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -47,7 +47,7 @@ function ChatView() {
 
   return (
     <div className="min-h-full lg:h-full w-full flex flex-col lg:flex-row transition-all duration-300 lg:relative lg:bg-paper-background">
-      <div className="flex-1 lg:flex-none lg:my-0 w-full lg:w-3/5 flex lg:order-2">
+      <div className="flex-1 lg:my-0 w-full lg:flex-1 flex lg:order-2">
         <MessageContainer isOngoing={isOngoing} letterContent={letterContent}>
           <div
             className={clsx(

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -5,13 +5,11 @@ import { useLetterContent } from "./hooks/useLetterContent";
 import ChatDisclaimer from "./pages/Chat/components/ChatDisclaimer";
 import FrequentInquiries from "./pages/Chat/components/FrequentInquiries";
 import MessageContainer from "./shared/components/MessageContainer";
-import FeatureSnippet from "./shared/components/FeatureSnippet";
+import FeaturesPanel from "./shared/components/FeaturesPanel";
 import MobilePanel from "./shared/components/MobilePanel";
 import { Navigate, useParams } from "react-router-dom";
 import { classifyStateSegment } from "./shared/utils/jurisdiction";
 import { DEFAULT_JURISDICTION } from "./shared/constants/jurisdictions";
-import { useState } from "react";
-import ChevronRight from "./shared/components/ChevronRight";
 import clsx from "clsx";
 
 /**
@@ -46,7 +44,6 @@ function ChatView() {
   const { addMessage, messages, setMessages } = useMessages();
   const isOngoing = messages.length > 0;
   const { letterContent } = useLetterContent(messages);
-  const [featuresOpen, setFeaturesOpen] = useState(true);
 
   return (
     <div className="min-h-full lg:h-full w-full flex flex-col lg:flex-row transition-all duration-300 lg:relative lg:bg-paper-background">
@@ -83,52 +80,7 @@ function ChatView() {
           </div>
         </MobilePanel>
       </div>
-      <button
-        type="button"
-        onClick={() => setFeaturesOpen(!featuresOpen)}
-        className={clsx(
-          "hidden lg:flex items-center justify-center", 
-          "absolute top-4 z-10",
-          "w-6 h-6 bg-paper-background border border-gray-light rounded-l-md",
-          "transition-[right] duration-300 ease-in-out",
-          featuresOpen ? "right-[20%]" : "right-0",
-        )}
-        >
-          <span
-            className={clsx(
-              "transition-transform duration-300",
-              featuresOpen ? "rotate-0" : "rotate-180",
-            )}
-          >
-            <ChevronRight size={14} />
-          </span>
-        </button>
-      <div
-        className={clsx(
-          "flex flex-col w-full bg-paper-background",
-          "border-b lg:border-b-0 border-gray-light",
-          "lg:order-3 lg:my-0 lg:ml-auto",
-          "lg:transition-[width] lg:duration-300 lg:ease-in-out overflow-hidden",
-          featuresOpen ? "lg:w-1/5" : "lg:w-0",
-          "[@media(max-height:800px)]:my-0 [@media(max-height:800px)]:self-stretch [@media(max-height:800px)]:overflow-hidden",
-        )}
-      >        
-        <div className={clsx(
-          "flex-1 flex flex-col min-w-0 lg:border-l border-gray-light",
-          "lg:transition-opacity lg:duration-300",
-          "lg:w-[20vw]",
-          featuresOpen ? "lg:opacity-100" : "lg:opacity-0 pointer-events-none",
-        )}>
-          <MobilePanel title="Features">
-            <div className="flex flex-col flex-1 min-h-0 lg:overflow-y-auto [@media(max-height:800px)]:overflow-y-auto">
-              <FeatureSnippet />
-            </div>
-          </MobilePanel>
-          <div className="p-4 [@media(min-width:1024px)_and_(min-height:801px)]:mt-auto">
-            <ChatDisclaimer isOngoing={isOngoing} />
-          </div>
-        </div>
-      </div>
+      <FeaturesPanel disclaimer={<ChatDisclaimer isOngoing={isOngoing} />} />
     </div>
   );
 }

--- a/frontend/src/Letter.tsx
+++ b/frontend/src/Letter.tsx
@@ -189,7 +189,7 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
     <>
       <LetterGenerationDialog ref={dialogRef} />
       <div className="min-h-full lg:h-full w-full flex flex-col lg:flex-row transition-all duration-300 lg:relative lg:bg-paper-background">
-        <div className="flex-1 lg:flex-none lg:my-0 w-full lg:w-3/5 flex lg:order-2">
+        <div className="flex-1 lg:my-0 w-full lg:flex-1 flex lg:order-2">
           <MessageContainer isOngoing={isOngoing} letterContent={letterContent}>
             <div
               className={clsx(
@@ -228,7 +228,9 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
             </div>
           </MobilePanel>
         </div>
-        <FeaturesPanel disclaimer={<LetterDisclaimer isOngoing={isOngoing} />} />
+        <FeaturesPanel
+          disclaimer={<LetterDisclaimer isOngoing={isOngoing} />}
+        />
       </div>
     </>
   );

--- a/frontend/src/Letter.tsx
+++ b/frontend/src/Letter.tsx
@@ -23,7 +23,7 @@ import MessageContainer from "./shared/components/MessageContainer";
 import useHousingContext from "./hooks/useHousingContext";
 import { buildChatUserMessage } from "./pages/Chat/utils/formHelper";
 import type { Location } from "./types/models";
-import FeatureSnippet from "./shared/components/FeatureSnippet";
+import FeaturesPanel from "./shared/components/FeaturesPanel";
 import FrequentInquiries from "./pages/Chat/components/FrequentInquiries";
 import MobilePanel from "./shared/components/MobilePanel";
 import clsx from "clsx";
@@ -188,7 +188,7 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
   return (
     <>
       <LetterGenerationDialog ref={dialogRef} />
-      <div className="min-h-full lg:h-full w-full flex flex-col lg:flex-row transition-all duration-300">
+      <div className="min-h-full lg:h-full w-full flex flex-col lg:flex-row transition-all duration-300 lg:relative lg:bg-paper-background">
         <div className="flex-1 lg:flex-none lg:my-0 w-full lg:w-3/5 flex lg:order-2">
           <MessageContainer isOngoing={isOngoing} letterContent={letterContent}>
             <div
@@ -228,23 +228,7 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
             </div>
           </MobilePanel>
         </div>
-        <div
-          className={clsx(
-            "flex flex-col w-full bg-paper-background",
-            "border-b lg:border-b-0 border-gray-light",
-            "lg:order-3 lg:my-0 lg:w-1/5 lg:border-l",
-            "[@media(max-height:800px)]:my-0 [@media(max-height:800px)]:self-stretch [@media(max-height:800px)]:overflow-hidden",
-          )}
-        >
-          <MobilePanel title="Features">
-            <div className="flex flex-col flex-1 min-h-0 lg:overflow-y-auto [@media(max-height:800px)]:overflow-y-auto">
-              <FeatureSnippet />
-            </div>
-          </MobilePanel>
-          <div className="p-4 [@media(min-width:1024px)_and_(min-height:801px)]:mt-auto">
-            <LetterDisclaimer isOngoing={isOngoing} />
-          </div>
-        </div>
+        <FeaturesPanel disclaimer={<LetterDisclaimer isOngoing={isOngoing} />} />
       </div>
     </>
   );

--- a/frontend/src/shared/components/FeaturesPanel.tsx
+++ b/frontend/src/shared/components/FeaturesPanel.tsx
@@ -44,7 +44,7 @@ export default function FeaturesPanel({ disclaimer }: Props) {
                 )}
             >        
                 <div className={clsx(
-                        "flex-1 flex flex-col min-w-0 lg:border-l border-gray-light",
+                        "flex-1 flex flex-col min-w-0 min-h-0 lg:border-l border-gray-light",
                         "lg:transition-opacity lg:duration-300",
                         "lg:w-[20vw]",
                         open ? "lg:opacity-100" : "lg:opacity-0 pointer-events-none",

--- a/frontend/src/shared/components/FeaturesPanel.tsx
+++ b/frontend/src/shared/components/FeaturesPanel.tsx
@@ -22,8 +22,8 @@ export default function FeaturesPanel({ disclaimer }: Props) {
         aria-controls="features-panel-content"
         aria-label="Toggle Features panel"
         onClick={() => {
-            setOpen(!open);
-            localStorage.setItem("featuresPanelOpen", String(!open));
+          setOpen(!open);
+          localStorage.setItem("featuresPanelOpen", String(!open));
         }}
         className={clsx(
           "hidden lg:flex items-center justify-center",

--- a/frontend/src/shared/components/FeaturesPanel.tsx
+++ b/frontend/src/shared/components/FeaturesPanel.tsx
@@ -15,6 +15,8 @@ export default function FeaturesPanel({ disclaimer }: Props) {
         <>
             <button
                 type="button"
+                aria-expanded={open}
+                aria-label="Toggle Features panel"
                 onClick={() => setOpen(!open)}
                 className={clsx(
                     "hidden lg:flex items-center justify-center", 

--- a/frontend/src/shared/components/FeaturesPanel.tsx
+++ b/frontend/src/shared/components/FeaturesPanel.tsx
@@ -3,12 +3,14 @@ import clsx from "clsx";
 import ChevronRight from "./ChevronRight";
 import MobilePanel from "./MobilePanel";
 import FeatureSnippet from "./FeatureSnippet";
+import { useIsMobile } from "../../hooks/useIsMobile"; 
 
 interface Props {
   disclaimer: React.ReactNode;
 }
 
 export default function FeaturesPanel({ disclaimer }: Props) {
+  const isMobile = useIsMobile();
   const [open, setOpen] = useState(() => {
     const saved = localStorage.getItem("featuresPanelOpen");
     return saved === null ? true : saved === "true";
@@ -55,12 +57,12 @@ export default function FeaturesPanel({ disclaimer }: Props) {
       >
         <div
           id="features-panel-content"
-          inert={!open || undefined}
+          inert={!isMobile && !open || undefined}
           className={clsx(
             "flex-1 flex flex-col min-w-0 min-h-0 lg:border-l border-gray-light",
             "lg:transition-opacity lg:duration-300",
             "lg:w-[var(--features-w)]",
-            open ? "lg:opacity-100" : "lg:opacity-0 pointer-events-none",
+            open ? "lg:opacity-100" : "lg:opacity-0 lg:pointer-events-none",
           )}
         >
           <MobilePanel title="Features">

--- a/frontend/src/shared/components/FeaturesPanel.tsx
+++ b/frontend/src/shared/components/FeaturesPanel.tsx
@@ -9,61 +9,70 @@ interface Props {
 }
 
 export default function FeaturesPanel({ disclaimer }: Props) {
-    const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(() => {
+    const saved = localStorage.getItem("featuresPanelOpen");
+    return saved === null ? true : saved === "true";
+  });
 
-    return (
-        <>
-            <button
-                type="button"
-                aria-expanded={open}
-                aria-label="Toggle Features panel"
-                onClick={() => setOpen(!open)}
-                className={clsx(
-                    "hidden lg:flex items-center justify-center", 
-                    "absolute top-4 z-10",
-                    "w-6 h-6 bg-paper-background border border-gray-light rounded-l-md",
-                    "transition-[right] duration-300 ease-in-out",
-                    open ? "right-[20%]" : "right-0",
-                )}
-            >
-                <span
-                    className={clsx(
-                        "transition-transform duration-300", 
-                        open ? "rotate-0" : "rotate-180",
-                )}
-                >
-                    <ChevronRight size={14} />
-                </span>
-            </button>
-            <div
-                className={clsx(
-                    "flex flex-col w-full bg-paper-background",
-                    "border-b lg:border-b-0 border-gray-light",
-                    "lg:order-3 lg:my-0 lg:ml-auto",
-                    "lg:transition-[width] lg:duration-300 lg:ease-in-out overflow-hidden",
-                    open ? "lg:w-1/5" : "lg:w-0",
-                    "[@media(max-height:800px)]:my-0 [@media(max-height:800px)]:self-stretch [@media(max-height:800px)]:overflow-hidden",
-                )}
-            >        
-                <div className={clsx(
-                        "flex-1 flex flex-col min-w-0 min-h-0 lg:border-l border-gray-light",
-                        "lg:transition-opacity lg:duration-300",
-                        "lg:w-[20vw]",
-                        open ? "lg:opacity-100" : "lg:opacity-0 pointer-events-none",
-                    )}
-                >
-                    <MobilePanel title="Features">
-                        <div className="flex flex-col flex-1 min-h-0 lg:overflow-y-auto [@media(max-height:800px)]:overflow-y-auto">
-                        <FeatureSnippet />
-                        </div>
-                    </MobilePanel>
-                    <div className="p-4 [@media(min-width:1024px)_and_(min-height:801px)]:mt-auto">
-                        {disclaimer}
-                    </div>
-                </div>
+  return (
+    <>
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls="features-panel-content"
+        aria-label="Toggle Features panel"
+        onClick={() => {
+            setOpen(!open);
+            localStorage.setItem("featuresPanelOpen", String(!open));
+        }}
+        className={clsx(
+          "hidden lg:flex items-center justify-center",
+          "absolute top-4 z-10",
+          "w-6 h-6 bg-paper-background border border-gray-light rounded-l-md",
+          "transition-[right] duration-300 ease-in-out",
+          open ? "right-[20%]" : "right-0",
+        )}
+      >
+        <span
+          className={clsx(
+            "transition-transform duration-300",
+            open ? "rotate-0" : "rotate-180",
+          )}
+        >
+          <ChevronRight size={14} />
+        </span>
+      </button>
+      <div
+        style={{ "--features-w": "20vw" } as React.CSSProperties}
+        className={clsx(
+          "flex flex-col w-full bg-paper-background",
+          "border-b lg:border-b-0 border-gray-light",
+          "lg:order-3 lg:my-0 lg:ml-auto",
+          "lg:transition-[width] lg:duration-300 lg:ease-in-out overflow-hidden",
+          open ? "lg:w-[var(--features-w)]" : "lg:w-0",
+          "[@media(max-height:800px)]:my-0 [@media(max-height:800px)]:self-stretch [@media(max-height:800px)]:overflow-hidden",
+        )}
+      >
+        <div
+          id="features-panel-content"
+          inert={!open || undefined}
+          className={clsx(
+            "flex-1 flex flex-col min-w-0 min-h-0 lg:border-l border-gray-light",
+            "lg:transition-opacity lg:duration-300",
+            "lg:w-[var(--features-w)]",
+            open ? "lg:opacity-100" : "lg:opacity-0 pointer-events-none",
+          )}
+        >
+          <MobilePanel title="Features">
+            <div className="flex flex-col flex-1 min-h-0 lg:overflow-y-auto [@media(max-height:800px)]:overflow-y-auto">
+              <FeatureSnippet />
             </div>
-        </>
-    
-    )
-    
+          </MobilePanel>
+          <div className="p-4 [@media(min-width:1024px)_and_(min-height:801px)]:mt-auto">
+            {disclaimer}
+          </div>
+        </div>
+      </div>
+    </>
+  );
 }

--- a/frontend/src/shared/components/FeaturesPanel.tsx
+++ b/frontend/src/shared/components/FeaturesPanel.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import clsx from "clsx";
+import ChevronRight from "./ChevronRight";
+import MobilePanel from "./MobilePanel";
+import FeatureSnippet from "./FeatureSnippet";
+
+interface Props {
+  disclaimer: React.ReactNode;
+}
+
+export default function FeaturesPanel({ disclaimer }: Props) {
+    const [open, setOpen] = useState(true);
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() => setOpen(!open)}
+                className={clsx(
+                    "hidden lg:flex items-center justify-center", 
+                    "absolute top-4 z-10",
+                    "w-6 h-6 bg-paper-background border border-gray-light rounded-l-md",
+                    "transition-[right] duration-300 ease-in-out",
+                    open ? "right-[20%]" : "right-0",
+                )}
+            >
+                <span
+                    className={clsx(
+                        "transition-transform duration-300", 
+                        open ? "rotate-0" : "rotate-180",
+                )}
+                >
+                    <ChevronRight size={14} />
+                </span>
+            </button>
+            <div
+                className={clsx(
+                    "flex flex-col w-full bg-paper-background",
+                    "border-b lg:border-b-0 border-gray-light",
+                    "lg:order-3 lg:my-0 lg:ml-auto",
+                    "lg:transition-[width] lg:duration-300 lg:ease-in-out overflow-hidden",
+                    open ? "lg:w-1/5" : "lg:w-0",
+                    "[@media(max-height:800px)]:my-0 [@media(max-height:800px)]:self-stretch [@media(max-height:800px)]:overflow-hidden",
+                )}
+            >        
+                <div className={clsx(
+                        "flex-1 flex flex-col min-w-0 lg:border-l border-gray-light",
+                        "lg:transition-opacity lg:duration-300",
+                        "lg:w-[20vw]",
+                        open ? "lg:opacity-100" : "lg:opacity-0 pointer-events-none",
+                    )}
+                >
+                    <MobilePanel title="Features">
+                        <div className="flex flex-col flex-1 min-h-0 lg:overflow-y-auto [@media(max-height:800px)]:overflow-y-auto">
+                        <FeatureSnippet />
+                        </div>
+                    </MobilePanel>
+                    <div className="p-4 [@media(min-width:1024px)_and_(min-height:801px)]:mt-auto">
+                        {disclaimer}
+                    </div>
+                </div>
+            </div>
+        </>
+    
+    )
+    
+}

--- a/frontend/src/tests/components/FeaturesPanel.test.tsx
+++ b/frontend/src/tests/components/FeaturesPanel.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import FeaturesPanel from "../../shared/components/FeaturesPanel";
+
+// MobilePanel uses window.matchMedia to watch the lg breakpoint.
+vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
+  matches: false,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+}));
+
+const renderPanel = (disclaimer = <p>Disclaimer text</p>) =>
+  render(<FeaturesPanel disclaimer={disclaimer} />);
+
+describe("FeaturesPanel", () => {
+  it("renders open by default", () => {
+    renderPanel();
+    expect(getToggle()).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("renders features content", () => {
+    renderPanel();
+    expect(
+      screen.getByText(/instant answers to common rental questions/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the disclaimer prop", () => {
+    renderPanel(<p>Custom disclaimer</p>);
+    expect(screen.getByText("Custom disclaimer")).toBeInTheDocument();
+  });
+
+  it("closes when the toggle button is clicked", () => {
+    renderPanel();
+    fireEvent.click(getToggle());
+    expect(getToggle()).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("reopens when the toggle button is clicked a second time", () => {
+    renderPanel();
+    fireEvent.click(getToggle());
+    fireEvent.click(getToggle());
+    expect(getToggle()).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("applies opacity class to content when closed", () => {
+    const { container } = renderPanel();
+    fireEvent.click(getToggle());
+    const contentWrapper = container.querySelector(".lg\\:opacity-0");
+    expect(contentWrapper).toBeInTheDocument();
+  });
+
+  it("removes opacity class from content when open", () => {
+    const { container } = renderPanel();
+    const contentWrapper = container.querySelector(".lg\\:opacity-0");
+    expect(contentWrapper).not.toBeInTheDocument();
+  });
+});
+
+function getToggle() {
+  return screen.getByRole("button", { name: /toggle features panel/i });
+}

--- a/frontend/src/tests/components/FeaturesPanel.test.tsx
+++ b/frontend/src/tests/components/FeaturesPanel.test.tsx
@@ -3,11 +3,14 @@ import { describe, it, expect, vi } from "vitest";
 import FeaturesPanel from "../../shared/components/FeaturesPanel";
 
 // MobilePanel uses window.matchMedia to watch the lg breakpoint.
-vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({
-  matches: false,
-  addEventListener: vi.fn(),
-  removeEventListener: vi.fn(),
-}));
+vi.stubGlobal(
+  "matchMedia",
+  vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }),
+);
 
 const renderPanel = (disclaimer = <p>Disclaimer text</p>) =>
   render(<FeaturesPanel disclaimer={disclaimer} />);

--- a/frontend/src/tests/components/FeaturesPanel.test.tsx
+++ b/frontend/src/tests/components/FeaturesPanel.test.tsx
@@ -2,15 +2,19 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import FeaturesPanel from "../../shared/components/FeaturesPanel";
 
-// MobilePanel uses window.matchMedia to watch the lg breakpoint.
-vi.stubGlobal(
-  "matchMedia",
-  vi.fn().mockReturnValue({
-    matches: false,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-  }),
-);
+// Both MobilePanel and useIsMobile query window.matchMedia.
+// matches: false → (max-width:1023px) is false → desktop (isMobile = false).
+const stubMatchMedia = (matches: boolean) =>
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  );
+
+stubMatchMedia(false);
 
 const renderPanel = (disclaimer = <p>Disclaimer text</p>) =>
   render(<FeaturesPanel disclaimer={disclaimer} />);
@@ -18,6 +22,7 @@ const renderPanel = (disclaimer = <p>Disclaimer text</p>) =>
 describe("FeaturesPanel", () => {
   beforeEach(() => {
     localStorage.clear();
+    stubMatchMedia(false); // reset to desktop before each test
   });
 
   it("renders open by default", () => {
@@ -61,6 +66,25 @@ describe("FeaturesPanel", () => {
     const { container } = renderPanel();
     const contentWrapper = container.querySelector(".lg\\:opacity-0");
     expect(contentWrapper).not.toBeInTheDocument();
+  });
+
+  it("sets content inert when closed on desktop", () => {
+    const { container } = renderPanel();
+    fireEvent.click(getToggle());
+    expect(
+      container.querySelector("#features-panel-content"),
+    ).toHaveAttribute("inert");
+  });
+
+  it("does not set content inert on mobile even when desktop panel state is closed", () => {
+    // Simulate the bug scenario: panel was previously closed on desktop and
+    // persisted to localStorage, then the user opens the page on mobile.
+    localStorage.setItem("featuresPanelOpen", "false");
+    stubMatchMedia(true); // (max-width:1023px) matches → isMobile = true
+    const { container } = renderPanel();
+    expect(
+      container.querySelector("#features-panel-content"),
+    ).not.toHaveAttribute("inert");
   });
 });
 

--- a/frontend/src/tests/components/FeaturesPanel.test.tsx
+++ b/frontend/src/tests/components/FeaturesPanel.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import FeaturesPanel from "../../shared/components/FeaturesPanel";
 
 // MobilePanel uses window.matchMedia to watch the lg breakpoint.
@@ -16,6 +16,10 @@ const renderPanel = (disclaimer = <p>Disclaimer text</p>) =>
   render(<FeaturesPanel disclaimer={disclaimer} />);
 
 describe("FeaturesPanel", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("renders open by default", () => {
     renderPanel();
     expect(getToggle()).toHaveAttribute("aria-expanded", "true");


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Infrastructure
- [ ] Maintenance

## Description

Added toggle to Features sidebar in /chat and /letter. Sidebar collapses to the right with chevron button+opacity fade and center chat component expands to fill space. Accessibility tree hides column contents when closed and toggle preference persists across pages. Added FeaturesPanel shared component which extracts toggle functionality for the column w/ disclaimer prop. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings


https://github.com/user-attachments/assets/7c3f1c49-68c7-4f91-8ae3-6502db434ed5



## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## Documentation

- [X] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?
