### PR TITLE
Add Lighthouse CI quality-gate to PR checks

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -163,3 +163,33 @@ jobs:
 
       - name: Build frontend
         run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          retention-days: 1
+
+  lighthouse:
+    runs-on: ubuntu-latest
+    needs: frontend-build
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: frontend/lighthouserc.json
+          uploadArtifacts: false
+          temporaryPublicStorage: false

--- a/frontend/lighthouserc.json
+++ b/frontend/lighthouserc.json
@@ -1,0 +1,15 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./frontend/dist"
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.7 }],
+        "categories:accessibility": ["error", { "minScore": 0.85 }],
+        "categories:best-practices": ["error", { "minScore": 0.95 }],
+        "categories:seo": ["error", { "minScore": 0.9 }]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Infrastructure
- [ ] Maintenance

## Description
Adds a Lighthouse CI quality-gate job to the PR check workflow. 
The job runs after frontend-build and audits the production build 
against baseline score thresholds to prevent frontend regressions.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #
- Closes #267

## QA Instructions, Screenshots, Recordings

Push a commit to this PR and check the Actions tab — the lighthouse 
job should appear and run after frontend-build completes.


## Added/updated tests?

- [ ] Yes
- [ X] No, and this is why: Lighthouse CI itself is the quality gate — no additional unit tests required for a CI config change.
- [ ] I need help with writing tests

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?
