### PR TITLE
Session storage chat message history

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -275,19 +275,11 @@ const serializedMsg = messages.map((msg) => ({
 }));
 ```
 
-**Session Data Structure:**
+`deserializeAiMessage` strips the JSONL streaming chunks stored in AI message content back to plain text before sending to the backend.
 
-```typescript
-interface TenantSessionData {
-  city: string; // User's city (e.g., "portland", "eugene", "null")
-  state: string; // User's state (default: "or")
-  messages: Array<{
-    // Complete conversation history
-    role: "human" | "ai";
-    content: string;
-  }>;
-}
-```
+**Client-Side Message Persistence:**
+
+`useMessages` accepts an optional `storageKey`. When it exists, it loads state from `sessionStorage` on mount and syncs every state change back to it. 
 
 **Multi-Turn Implementation Details:**
 
@@ -432,7 +424,7 @@ frontend/
 │   │   └── HousingContext.tsx      # Housing context for chat/letter generation
 │   ├── hooks/                      # Custom React hooks
 │   │   ├── useIsMobile.tsx         # Checking mobile state
-│   │   ├── useMessages.tsx         # Message handling logic
+│   │   ├── useMessages.tsx         # Message handling + persistence logic
 │   │   ├── useHousingContext.tsx   # Custom hook for housing context
 │   │   └── useLetterContent.tsx    # State management for letter generation
 │   ├── types/                      # Auto-generated TypeScript types (gitignored) — do not edit manually, re-run `make generate-types` or `npm run generate-types`
@@ -483,7 +475,8 @@ frontend/
 │   │       ├── buildLocationPrefix.ts # Helper function for location prefix
 │   │       ├── scrolling.ts        # Helper function for window scrolling
 │   │       ├── dompurify.ts        # Helper function for sanitizing text
-│   │       └── formatLocation.ts   # Formats OregonCity/UsaState into a display string (e.g. "Portland, OR")
+│   │       ├── formatLocation.ts   # Formats OregonCity/UsaState into a display string (e.g. "Portland, OR")
+│   │       └── reloadPage.ts       # Wrapper around window.location.reload()
 │   └── tests/                     # Testing suite
 │   │   ├── components/            # Component testing
 │   │   │   ├── About.test.tsx     # About component testing

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -59,6 +59,7 @@ function ChatView() {
             )}
           >
             <MessageWindow
+              mode="chat"
               messages={messages}
               addMessage={addMessage}
               setMessages={setMessages}

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -41,7 +41,7 @@ export default function Chat() {
 
 function ChatView() {
   useSyncJurisdiction();
-  const { addMessage, messages, setMessages } = useMessages();
+  const { addMessage, messages, setMessages, clearMessages } = useMessages("chat_messages");
   const isOngoing = messages.length > 0;
   const { letterContent } = useLetterContent(messages);
 
@@ -61,6 +61,7 @@ function ChatView() {
               addMessage={addMessage}
               setMessages={setMessages}
               isOngoing={isOngoing}
+              clearMessages={clearMessages}
             />
           </div>
         </MessageContainer>

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -8,7 +8,7 @@ import MessageContainer from "./shared/components/MessageContainer";
 import FeaturesPanel from "./shared/components/FeaturesPanel";
 import MobilePanel from "./shared/components/MobilePanel";
 import { Navigate, useParams } from "react-router-dom";
-import { classifyStateSegment, pathFor } from "./shared/utils/jurisdiction";
+import { classifyStateSegment, pathFor, resolveJurisdiction } from "./shared/utils/jurisdiction";
 import { DEFAULT_JURISDICTION } from "./shared/constants/jurisdictions";
 import clsx from "clsx";
 
@@ -41,7 +41,9 @@ export default function Chat() {
 
 function ChatView() {
   useSyncJurisdiction();
-  const { addMessage, messages, setMessages, clearMessages } = useMessages("chat_messages");
+  const { state, city } = useParams();
+  const jurisdiction = resolveJurisdiction(state, city);
+  const { addMessage, messages, setMessages, clearMessages } = useMessages(`chat_messages:${jurisdiction.key}`);
   const isOngoing = messages.length > 0;
   const { letterContent } = useLetterContent(messages);
 

--- a/frontend/src/Letter.tsx
+++ b/frontend/src/Letter.tsx
@@ -86,7 +86,7 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
   const { letterContent } = useLetterContent(messages);
   const [startStreaming, setStartStreaming] = useState(false);
   const streamLocationRef = useRef<Location | null>(null);
-  const [isGenerating, setIsGenerating] = useState(true);
+  const [isGenerating, setIsGenerating] = useState(letterContent === "");
   const dialogRef = useRef<HTMLDialogElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasInitialized = useRef(false);
@@ -107,24 +107,33 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
   // Adds the initial user message once and triggers streaming.
   useEffect(() => {
     if (hasInitialized.current) return;
+    hasInitialized.current = true;
+
+    if (letterContent !== "") {
+      setIsGenerating(false);
+      return;
+    }
+
     const loc = toLocation(jurisdiction);
     const output = buildLetterUserMessage(org, loc);
-    hasInitialized.current = true;
-    const userMessageId = Date.now().toString();
-    const content = [
-      buildLocationPrefix(loc.city, loc.state),
-      issueDescription,
-      output.userMessage,
-    ]
-      .join(" ")
-      .trim();
-    setMessages((prev) => [
-      ...prev,
-      new HumanMessage({ content, id: userMessageId }),
-    ]);
+
+    if (messages.length === 0) {
+      const userMessageId = Date.now().toString();
+      const content = [
+        buildLocationPrefix(loc.city, loc.state),
+        issueDescription,
+        output.userMessage,
+      ]
+        .join(" ")
+        .trim();
+      setMessages((prev) => [
+        ...prev,
+        new HumanMessage({ content, id: userMessageId }),
+      ]);
+    }
     streamLocationRef.current = output.selectedLocation;
     setStartStreaming(true);
-  }, [jurisdiction, org, setMessages, issueDescription]);
+  }, [jurisdiction, org, setMessages, issueDescription, letterContent, messages.length]);
 
   useEffect(() => {
     if (startStreaming === false || streamLocationRef.current === null) return;

--- a/frontend/src/Letter.tsx
+++ b/frontend/src/Letter.tsx
@@ -190,6 +190,11 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
     dialogRef.current?.showModal();
   }, []);
 
+  function handleClearMessages() {
+    clearMessages();
+    window.location.reload();
+  }
+  
   return (
     <>
       <LetterGenerationDialog ref={dialogRef} />
@@ -210,11 +215,12 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
                 </div>
               ) : (
                 <MessageWindow
+                  mode="letter"
                   messages={messages}
                   addMessage={addMessage}
                   setMessages={setMessages}
                   isOngoing={isOngoing}
-                  clearMessages={clearMessages}
+                  clearMessages={handleClearMessages}
                 />
               )}
             </div>

--- a/frontend/src/Letter.tsx
+++ b/frontend/src/Letter.tsx
@@ -81,7 +81,7 @@ interface LetterViewProps {
 }
 
 function LetterView({ jurisdiction, org }: LetterViewProps) {
-  const { addMessage, messages, setMessages, clearMessages } = useMessages();
+  const { addMessage, messages, setMessages, clearMessages } = useMessages(`letter_messages:${jurisdiction.key},${org ?? ""}`);
   const isOngoing = messages.length > 0;
   const { letterContent } = useLetterContent(messages);
   const [startStreaming, setStartStreaming] = useState(false);

--- a/frontend/src/Letter.tsx
+++ b/frontend/src/Letter.tsx
@@ -28,6 +28,7 @@ import FrequentInquiries from "./pages/Chat/components/FrequentInquiries";
 import MobilePanel from "./shared/components/MobilePanel";
 import clsx from "clsx";
 import { buildLocationPrefix } from "./shared/utils/buildLocationPrefix";
+import { reloadPage } from "./shared/utils/reloadPage";
 
 /**
  * Routes /letter requests by classifying the leading segment: an out-of-state
@@ -192,9 +193,9 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
 
   function handleClearMessages() {
     clearMessages();
-    window.location.reload();
+    reloadPage();
   }
-  
+
   return (
     <>
       <LetterGenerationDialog ref={dialogRef} />

--- a/frontend/src/Letter.tsx
+++ b/frontend/src/Letter.tsx
@@ -81,7 +81,7 @@ interface LetterViewProps {
 }
 
 function LetterView({ jurisdiction, org }: LetterViewProps) {
-  const { addMessage, messages, setMessages } = useMessages();
+  const { addMessage, messages, setMessages, clearMessages } = useMessages();
   const isOngoing = messages.length > 0;
   const { letterContent } = useLetterContent(messages);
   const [startStreaming, setStartStreaming] = useState(false);
@@ -205,6 +205,7 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
                   addMessage={addMessage}
                   setMessages={setMessages}
                   isOngoing={isOngoing}
+                  clearMessages={clearMessages}
                 />
               )}
             </div>

--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -112,6 +112,9 @@ export default function useMessages(storageKey?: string) {
   });
 
   function clearMessages() {
+    if (storageKey) {
+      sessionStorage.removeItem(storageKey);
+    }
     setMessages([]);
   }
 

--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -1,8 +1,25 @@
 import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { Location } from "../types/models";
 import type { ChatMessage, UiMessage } from "../shared/types/messages";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
 
+
+type StoredMessage = { type: "human" | "ai"; content: string; id: string };
+
+function loadFromStorage(key: string): ChatMessage[] {
+  try {
+    const raw = sessionStorage.getItem(key);
+    if (!raw) return [];
+    const stored: StoredMessage[] = JSON.parse(raw);
+    return stored.map((msg) => 
+      msg.type === "human" ? new HumanMessage({ content: msg.content, id: msg.id }) 
+      : new AIMessage({ content: msg.content, id: msg.id })
+    )
+  } catch {
+    return [];
+  }
+}
 /**
  * Converts a stored AI message (JSONL chunks) back to plain text for backend
  * history.
@@ -45,8 +62,25 @@ async function addNewMessage(
  * Hook for managing chat messages and sending queries to the backend.
  * Provides message state, a setter, and a mutation for posting new messages.
  */
-export default function useMessages() {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+export default function useMessages(storageKey?: string) {
+  const [messages, setMessages] = useState<ChatMessage[]>(() => 
+    storageKey? loadFromStorage(storageKey) : []
+  );
+
+  useEffect(() => {
+    if (!storageKey) return;
+    const toStore: StoredMessage[] = messages
+    .filter(
+      (msg): msg is Exclude<ChatMessage, UiMessage> => 
+        msg.type !== "ui" && msg.text.trim() !== ""
+    )
+    .map((msg) => ({
+      type: msg instanceof HumanMessage ? "human" : "ai",
+      content: typeof msg.content === "string" ? msg.content : msg.text,
+      id: msg.id ?? "",
+    }));
+    sessionStorage.setItem(storageKey, JSON.stringify(toStore));
+  }, [messages, storageKey])
 
   const addMessage = useMutation({
     mutationFn: async ({ city, state }: Location) => {
@@ -59,9 +93,15 @@ export default function useMessages() {
     },
   });
 
+  function clearMessages() {
+    if (storageKey) sessionStorage.removeItem(storageKey);
+    setMessages([]);
+  }
+
   return {
     messages,
     setMessages,
     addMessage: addMessage.mutateAsync,
+    clearMessages,
   };
 }

--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -79,7 +79,7 @@ export default function useMessages(storageKey?: string) {
       content: typeof msg.content === "string" ? msg.content : msg.text,
       id: msg.id ?? "",
     }));
-    sessionStorage.setItem(storageKey, JSON.stringify(toStore));
+    toStore.length === 0 ? sessionStorage.removeItem(storageKey) : sessionStorage.setItem(storageKey, JSON.stringify(toStore));
   }, [messages, storageKey])
 
   const addMessage = useMutation({
@@ -94,7 +94,6 @@ export default function useMessages(storageKey?: string) {
   });
 
   function clearMessages() {
-    if (storageKey) sessionStorage.removeItem(storageKey);
     setMessages([]);
   }
 

--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { Location } from "../types/models";
 import type { ChatMessage, UiMessage } from "../shared/types/messages";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
@@ -66,12 +66,22 @@ export default function useMessages(storageKey?: string) {
   const [messages, setMessages] = useState<ChatMessage[]>(() =>
     storageKey ? loadFromStorage(storageKey) : []
   );
+  // Refs to track storage key changes and prevent overwriting messages during extra setups/re-renders.
+  const loadedStorageKeyRef = useRef(storageKey);
+  const isChangingStorageKeyRef = useRef(false);
 
   useEffect(() => {
+    if (loadedStorageKeyRef.current === storageKey) return;
+    loadedStorageKeyRef.current = storageKey;
+    isChangingStorageKeyRef.current = true;
     setMessages(storageKey ? loadFromStorage(storageKey) : []);
   }, [storageKey]);
 
   useEffect(() => {
+    if (isChangingStorageKeyRef.current) {
+      isChangingStorageKeyRef.current = false;
+      return;
+    }
     if (!storageKey) return;
     const toStore: StoredMessage[] = messages
     .filter(

--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -63,9 +63,13 @@ async function addNewMessage(
  * Provides message state, a setter, and a mutation for posting new messages.
  */
 export default function useMessages(storageKey?: string) {
-  const [messages, setMessages] = useState<ChatMessage[]>(() => 
-    storageKey? loadFromStorage(storageKey) : []
+  const [messages, setMessages] = useState<ChatMessage[]>(() =>
+    storageKey ? loadFromStorage(storageKey) : []
   );
+
+  useEffect(() => {
+    setMessages(storageKey ? loadFromStorage(storageKey) : []);
+  }, [storageKey]);
 
   useEffect(() => {
     if (!storageKey) return;

--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -83,7 +83,11 @@ export default function useMessages(storageKey?: string) {
       content: typeof msg.content === "string" ? msg.content : msg.text,
       id: msg.id ?? "",
     }));
-    toStore.length === 0 ? sessionStorage.removeItem(storageKey) : sessionStorage.setItem(storageKey, JSON.stringify(toStore));
+    if (toStore.length === 0) {
+      sessionStorage.removeItem(storageKey);
+      return;
+    } 
+    sessionStorage.setItem(storageKey, JSON.stringify(toStore));
   }, [messages, storageKey])
 
   const addMessage = useMutation({

--- a/frontend/src/pages/Chat/components/MessageWindow.tsx
+++ b/frontend/src/pages/Chat/components/MessageWindow.tsx
@@ -17,6 +17,7 @@ interface Props {
   ) => Promise<ReadableStreamDefaultReader<Uint8Array> | undefined>;
   setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
   isOngoing: boolean;
+  clearMessages: () => void;
 }
 
 /**
@@ -28,6 +29,7 @@ export default function MessageWindow({
   addMessage,
   setMessages,
   isOngoing,
+  clearMessages,
 }: Props) {
   const [isLoading, setIsLoading] = useState(false);
   const [inputValue, setInputValue] = useState("");
@@ -44,7 +46,7 @@ export default function MessageWindow({
     : messages;
 
   const handleClearSession = () => {
-    window.location.reload();
+    clearMessages();
   };
 
   useEffect(() => {

--- a/frontend/src/pages/Chat/components/MessageWindow.tsx
+++ b/frontend/src/pages/Chat/components/MessageWindow.tsx
@@ -7,10 +7,12 @@ import ExportMessagesButton from "./ExportMessagesButton";
 import InitializationForm from "./InitializationForm";
 import MessageAvatar from "./MessageAvatar";
 import FeedbackModal from "./FeedbackModal";
-import { useLocation } from "react-router-dom";
 import clsx from "clsx";
 
+type MessageWindowMode = "chat" | "letter";
+
 interface Props {
+  mode: MessageWindowMode;
   messages: ChatMessage[];
   addMessage: (
     args: Location,
@@ -25,6 +27,7 @@ interface Props {
  * Shows the initialization form when no messages exist.
  */
 export default function MessageWindow({
+  mode,
   messages,
   addMessage,
   setMessages,
@@ -36,12 +39,11 @@ export default function MessageWindow({
   const [openFeedback, setOpenFeedback] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const messagesRef = useRef<HTMLDivElement | null>(null);
-  const loc = useLocation();
 
   // Hides the initial user prompt and AI letter response on the letter page
   // (index 0 = user prompt, index 1 = AI letter generation).
   const LETTER_PAGE_HIDDEN_MESSAGES = 2;
-  const displayedMessages = loc.pathname.startsWith("/letter")
+  const displayedMessages = mode === "letter"
     ? messages.slice(LETTER_PAGE_HIDDEN_MESSAGES)
     : messages;
 
@@ -146,12 +148,12 @@ export default function MessageWindow({
               </button>
             </div>
           </>
-        ) : (
+        ) : mode === "chat" ? (
           <InitializationForm
             addMessage={addMessage}
             setMessages={setMessages}
           />
-        )}
+        ) : null}
       </div>
     </>
   );

--- a/frontend/src/shared/utils/reloadPage.ts
+++ b/frontend/src/shared/utils/reloadPage.ts
@@ -1,0 +1,3 @@
+export function reloadPage() {
+  window.location.reload();
+}

--- a/frontend/src/tests/components/Letter.test.tsx
+++ b/frontend/src/tests/components/Letter.test.tsx
@@ -16,7 +16,7 @@ import {
 } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
-import { HumanMessage } from "@langchain/core/messages";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import type { ChatMessage } from "../../shared/types/messages";
 
 beforeAll(() => {
@@ -38,7 +38,7 @@ vi.mock("../../hooks/useMessages", () => ({
 }));
 
 vi.mock("../../hooks/useLetterContent", () => ({
-  useLetterContent: () => ({ letterContent: "" }),
+  useLetterContent: vi.fn(),
 }));
 
 vi.mock("../../pages/Chat/components/MessageWindow", () => ({
@@ -56,10 +56,12 @@ vi.mock("../../LetterGenerationDialog", () => ({
 
 import * as streamHelper from "../../pages/Chat/utils/streamHelper";
 import useMessages from "../../hooks/useMessages";
+import { useLetterContent } from "../../hooks/useLetterContent";
 import HousingContextProvider from "../../contexts/HousingContext";
 
 let mockStreamText: ReturnType<typeof vi.fn>;
 let mockUseMessages: ReturnType<typeof vi.fn>;
+let mockUseLetterContent: ReturnType<typeof vi.fn>;
 
 const renderLetter = async (initialEntry = "/letter/or/portland?org=org") => {
   const { default: Letter } = await import("../../Letter");
@@ -81,9 +83,11 @@ describe("Letter component - effect orchestration", () => {
   beforeEach(() => {
     mockStreamText = vi.mocked(streamHelper.streamText);
     mockUseMessages = vi.mocked(useMessages);
+    mockUseLetterContent = vi.mocked(useLetterContent);
 
     mockStreamText.mockClear();
     mockStreamText.mockResolvedValue(undefined);
+    mockUseLetterContent.mockReturnValue({ letterContent: "" });
 
     mockUseMessages.mockReturnValue({
       addMessage: vi.fn(),
@@ -148,6 +152,62 @@ describe("Letter component - effect orchestration", () => {
     await waitFor(() => {
       expect(screen.queryByText("Generating Letter...")).not.toBeNull();
     });
+  });
+
+  it("restores a completed letter without generating it again", async () => {
+    const mockSetMessages = vi.fn();
+    mockUseMessages.mockReturnValue({
+      addMessage: vi.fn(),
+      messages: [
+        new HumanMessage({ content: "Generate my letter", id: "1" }),
+        new AIMessage({
+          content: '{"type":"letter","content":"Dear Landlord,"}\n',
+          id: "2",
+        }),
+      ],
+      setMessages: mockSetMessages,
+    });
+    mockUseLetterContent.mockReturnValue({
+      letterContent: "Dear Landlord,",
+    });
+
+    await renderLetter();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("message-window")).not.toBeNull();
+    });
+
+    expect(screen.queryByText("Generating Letter...")).toBeNull();
+    expect(mockSetMessages).not.toHaveBeenCalled();
+    expect(mockStreamText).not.toHaveBeenCalled();
+  });
+
+  it("retries an incomplete restored session without duplicating the prompt", async () => {
+    const mockSetMessages = vi.fn();
+    const restoredPrompt = new HumanMessage({
+      content: "Generate my letter",
+      id: "1",
+    });
+    mockUseMessages.mockReturnValue({
+      addMessage: vi.fn(),
+      messages: [restoredPrompt],
+      setMessages: mockSetMessages,
+    });
+
+    await renderLetter();
+
+    await waitFor(() => {
+      expect(mockStreamText).toHaveBeenCalled();
+    });
+
+    const duplicatedPrompt = mockSetMessages.mock.calls.some((call) => {
+      const update = call[0];
+      if (typeof update !== "function") return false;
+      const updatedMessages = update([restoredPrompt]) as ChatMessage[];
+      return updatedMessages.filter((message) => message.type === "human")
+        .length > 1;
+    });
+    expect(duplicatedPrompt).toBe(false);
   });
 
   it("dialog closes when close button clicked", async () => {

--- a/frontend/src/tests/components/Letter.test.tsx
+++ b/frontend/src/tests/components/Letter.test.tsx
@@ -42,7 +42,15 @@ vi.mock("../../hooks/useLetterContent", () => ({
 }));
 
 vi.mock("../../pages/Chat/components/MessageWindow", () => ({
-  default: () => <div data-testid="message-window" />,
+  default: ({ clearMessages }: { clearMessages: () => void }) => (
+    <div data-testid="message-window">
+      <button onClick={clearMessages}>Clear Letter</button>
+    </div>
+  ),
+}));
+
+vi.mock("../../shared/utils/reloadPage", () => ({
+  reloadPage: vi.fn(),
 }));
 
 vi.mock("../../LetterGenerationDialog", () => ({
@@ -57,11 +65,13 @@ vi.mock("../../LetterGenerationDialog", () => ({
 import * as streamHelper from "../../pages/Chat/utils/streamHelper";
 import useMessages from "../../hooks/useMessages";
 import { useLetterContent } from "../../hooks/useLetterContent";
+import { reloadPage } from "../../shared/utils/reloadPage";
 import HousingContextProvider from "../../contexts/HousingContext";
 
 let mockStreamText: ReturnType<typeof vi.fn>;
 let mockUseMessages: ReturnType<typeof vi.fn>;
 let mockUseLetterContent: ReturnType<typeof vi.fn>;
+let mockReloadPage: ReturnType<typeof vi.fn>;
 
 const renderLetter = async (initialEntry = "/letter/or/portland?org=org") => {
   const { default: Letter } = await import("../../Letter");
@@ -84,6 +94,7 @@ describe("Letter component - effect orchestration", () => {
     mockStreamText = vi.mocked(streamHelper.streamText);
     mockUseMessages = vi.mocked(useMessages);
     mockUseLetterContent = vi.mocked(useLetterContent);
+    mockReloadPage = vi.mocked(reloadPage);
 
     mockStreamText.mockClear();
     mockStreamText.mockResolvedValue(undefined);
@@ -93,6 +104,7 @@ describe("Letter component - effect orchestration", () => {
       addMessage: vi.fn(),
       messages: [],
       setMessages: vi.fn(),
+      clearMessages: vi.fn(),
     });
   });
 
@@ -166,6 +178,7 @@ describe("Letter component - effect orchestration", () => {
         }),
       ],
       setMessages: mockSetMessages,
+      clearMessages: vi.fn(),
     });
     mockUseLetterContent.mockReturnValue({
       letterContent: "Dear Landlord,",
@@ -192,6 +205,7 @@ describe("Letter component - effect orchestration", () => {
       addMessage: vi.fn(),
       messages: [restoredPrompt],
       setMessages: mockSetMessages,
+      clearMessages: vi.fn(),
     });
 
     await renderLetter();
@@ -208,6 +222,36 @@ describe("Letter component - effect orchestration", () => {
         .length > 1;
     });
     expect(duplicatedPrompt).toBe(false);
+  });
+
+  it("clears the letter before reloading the page", async () => {
+    const callOrder: string[] = [];
+    const mockClearMessages = vi.fn(() => {
+      callOrder.push("clear");
+    });
+    mockReloadPage.mockImplementation(() => {
+      callOrder.push("reload");
+    });
+    mockUseMessages.mockReturnValue({
+      addMessage: vi.fn(),
+      messages: [
+        new HumanMessage({ content: "Generate my letter", id: "1" }),
+        new AIMessage({
+          content: '{"type":"letter","content":"Dear Landlord,"}\n',
+          id: "2",
+        }),
+      ],
+      setMessages: vi.fn(),
+      clearMessages: mockClearMessages,
+    });
+    mockUseLetterContent.mockReturnValue({
+      letterContent: "Dear Landlord,",
+    });
+
+    await renderLetter();
+    fireEvent.click(screen.getByText("Clear Letter"));
+
+    expect(callOrder).toEqual(["clear", "reload"]);
   });
 
   it("dialog closes when close button clicked", async () => {

--- a/frontend/src/tests/components/MessageWindow.test.tsx
+++ b/frontend/src/tests/components/MessageWindow.test.tsx
@@ -25,6 +25,7 @@ describe("MessageWindow component", () => {
   ];
 
   const defaultProps = {
+    mode: "chat" as const,
     messages,
     addMessage: vi.fn(),
     setMessages: vi.fn(),
@@ -38,7 +39,7 @@ describe("MessageWindow component", () => {
       <QueryClientProvider client={queryClient}>
         <HousingContextProvider>
           <MemoryRouter initialEntries={["/letter/some-org"]}>
-            <MessageWindow {...defaultProps} />
+            <MessageWindow {...defaultProps} mode="letter" />
           </MemoryRouter>
         </HousingContextProvider>
       </QueryClientProvider>,
@@ -64,5 +65,44 @@ describe("MessageWindow component", () => {
     expect(screen.getByText("first message")).toBeInTheDocument();
     expect(screen.getByText("second message")).toBeInTheDocument();
     expect(screen.getByText("third message")).toBeInTheDocument();
+  });
+
+  it("does not show the chat initialization form for an empty letter", () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HousingContextProvider>
+          <MemoryRouter initialEntries={["/letter/or/portland"]}>
+            <MessageWindow
+              {...defaultProps}
+              mode="letter"
+              messages={[]}
+              isOngoing={false}
+            />
+          </MemoryRouter>
+        </HousingContextProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByText("Welcome to Tenant First Aid!")).toBeNull();
+  });
+
+  it("shows the chat initialization form for an empty chat", () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HousingContextProvider>
+          <MemoryRouter initialEntries={["/chat/or/portland"]}>
+            <MessageWindow
+              {...defaultProps}
+              messages={[]}
+              isOngoing={false}
+            />
+          </MemoryRouter>
+        </HousingContextProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText("Welcome to Tenant First Aid!")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/MessageWindow.test.tsx
+++ b/frontend/src/tests/components/MessageWindow.test.tsx
@@ -29,6 +29,7 @@ describe("MessageWindow component", () => {
     addMessage: vi.fn(),
     setMessages: vi.fn(),
     isOngoing: true,
+    clearMessages: vi.fn(),
   };
 
   it("hides first 2 messages on letter page", () => {

--- a/frontend/src/tests/components/MessageWindow.test.tsx
+++ b/frontend/src/tests/components/MessageWindow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import MessageWindow from "../../pages/Chat/components/MessageWindow";
@@ -104,5 +104,26 @@ describe("MessageWindow component", () => {
     );
 
     expect(screen.getByText("Welcome to Tenant First Aid!")).toBeInTheDocument();
+  });
+
+  it("delegates clearing to the provided callback", () => {
+    const clearMessages = vi.fn();
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HousingContextProvider>
+          <MemoryRouter initialEntries={["/chat/or/portland"]}>
+            <MessageWindow
+              {...defaultProps}
+              clearMessages={clearMessages}
+            />
+          </MemoryRouter>
+        </HousingContextProvider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "clear chat" }));
+
+    expect(clearMessages).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/tests/hooks/useMessages.test.ts
+++ b/frontend/src/tests/hooks/useMessages.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect } from "vitest";
-import { deserializeAiMessage } from "../../hooks/useMessages";
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HumanMessage, AIMessage } from "@langchain/core/messages";
+import useMessages, { deserializeAiMessage } from "../../hooks/useMessages";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    QueryClientProvider,
+    { client: new QueryClient() },
+    children,
+  );
+}
 
 describe("deserializeAiMessage", () => {
   it("extracts text from a text chunk", () => {
@@ -26,5 +38,78 @@ describe("deserializeAiMessage", () => {
     expect(deserializeAiMessage(input)).toBe(
       "What was generated is just an initial template.",
     );
+  });
+});
+
+describe("useMessages", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("starts with empty messages when no storageKey is given", () => {
+    const { result } = renderHook(() => useMessages(), { wrapper });
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("starts with empty messages when storageKey has no entry", () => {
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("loads messages from sessionStorage on init", () => {
+    const stored = [
+      { type: "human", content: "hello", id: "1" },
+      { type: "ai", content: "world", id: "2" },
+    ];
+    sessionStorage.setItem("test_key", JSON.stringify(stored));
+
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[0]).toBeInstanceOf(HumanMessage);
+    expect(result.current.messages[1]).toBeInstanceOf(AIMessage);
+  });
+
+  it("persists messages to sessionStorage when they change", () => {
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+
+    act(() => {
+      result.current.setMessages([
+        new HumanMessage({ content: "hi", id: "1" }),
+      ]);
+    });
+
+    const stored = JSON.parse(sessionStorage.getItem("test_key") ?? "[]");
+    expect(stored).toEqual([{ type: "human", content: "hi", id: "1" }]);
+  });
+
+  it("clearMessages resets state and removes the sessionStorage entry", () => {
+    sessionStorage.setItem(
+      "test_key",
+      JSON.stringify([{ type: "human", content: "hi", id: "1" }]),
+    );
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+
+    act(() => {
+      result.current.clearMessages();
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(sessionStorage.getItem("test_key")).toBe("[]");
+  });
+
+  it("clearMessages without a storageKey only resets state", () => {
+    const { result } = renderHook(() => useMessages(), { wrapper });
+
+    act(() => {
+      result.current.setMessages([
+        new HumanMessage({ content: "hi", id: "1" }),
+      ]);
+    });
+
+    act(() => {
+      result.current.clearMessages();
+    });
+
+    expect(result.current.messages).toEqual([]);
   });
 });

--- a/frontend/src/tests/hooks/useMessages.test.ts
+++ b/frontend/src/tests/hooks/useMessages.test.ts
@@ -1,6 +1,6 @@
-import React from "react";
-import { renderHook, act } from "@testing-library/react";
-import { describe, it, expect, beforeEach } from "vitest";
+import React, { useEffect, useRef, useState } from "react";
+import { render, renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HumanMessage, AIMessage } from "@langchain/core/messages";
 import useMessages, { deserializeAiMessage } from "../../hooks/useMessages";
@@ -46,6 +46,10 @@ describe("useMessages", () => {
     sessionStorage.clear();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("starts with empty messages when no storageKey is given", () => {
     const { result } = renderHook(() => useMessages(), { wrapper });
     expect(result.current.messages).toEqual([]);
@@ -80,6 +84,110 @@ describe("useMessages", () => {
 
     const stored = JSON.parse(sessionStorage.getItem("test_key") ?? "[]");
     expect(stored).toEqual([{ type: "human", content: "hi", id: "1" }]);
+  });
+
+  it("preserves and sends a guarded initial message in Strict Mode", async () => {
+    const reader = {} as ReadableStreamDefaultReader<Uint8Array>;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      body: { getReader: () => reader },
+    } as Response);
+
+    function LetterBootstrap() {
+      const { messages, setMessages, addMessage } =
+        useMessages("letter_messages:or-portland,");
+      const hasInitialized = useRef(false);
+      const [startStreaming, setStartStreaming] = useState(false);
+
+      useEffect(() => {
+        if (hasInitialized.current) return;
+        hasInitialized.current = true;
+        setMessages((previous) => [
+          ...previous,
+          new HumanMessage({ content: "Generate my letter", id: "1" }),
+        ]);
+        setStartStreaming(true);
+      }, [setMessages]);
+
+      useEffect(() => {
+        if (!startStreaming) return;
+        setStartStreaming(false);
+        void addMessage({ city: "portland", state: "or" });
+      }, [addMessage, startStreaming]);
+
+      return React.createElement(
+        "div",
+        { "data-testid": "message-count" },
+        messages.length,
+      );
+    }
+
+    const view = render(
+      React.createElement(
+        React.StrictMode,
+        null,
+        React.createElement(
+          QueryClientProvider,
+          { client: new QueryClient() },
+          React.createElement(LetterBootstrap),
+        ),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(view.getByTestId("message-count").textContent).toBe("1");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      JSON.parse(
+        sessionStorage.getItem("letter_messages:or-portland,") ?? "[]",
+      ),
+    ).toEqual([
+        { type: "human", content: "Generate my letter", id: "1" },
+    ]);
+
+    const request = fetchSpy.mock.calls[0]?.[1];
+    expect(JSON.parse(String(request?.body))).toEqual({
+      messages: [
+        { role: "human", content: "Generate my letter", id: "1" },
+      ],
+      city: "portland",
+      state: "or",
+    });
+  });
+
+  it("loads a new storage key without copying the previous conversation", async () => {
+    sessionStorage.setItem(
+      "second_key",
+      JSON.stringify([{ type: "human", content: "second", id: "2" }]),
+    );
+    const { result, rerender } = renderHook(
+      ({ storageKey }) => useMessages(storageKey),
+      {
+        initialProps: { storageKey: "first_key" },
+        wrapper,
+      },
+    );
+
+    act(() => {
+      result.current.setMessages([
+        new HumanMessage({ content: "first", id: "1" }),
+      ]);
+    });
+
+    rerender({ storageKey: "second_key" });
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0].text).toBe("second");
+    });
+
+    expect(JSON.parse(sessionStorage.getItem("first_key") ?? "[]")).toEqual([
+      { type: "human", content: "first", id: "1" },
+    ]);
+    expect(JSON.parse(sessionStorage.getItem("second_key") ?? "[]")).toEqual([
+      { type: "human", content: "second", id: "2" },
+    ]);
   });
 
   it("clearMessages resets state and removes the sessionStorage entry", () => {

--- a/frontend/src/tests/hooks/useMessages.test.ts
+++ b/frontend/src/tests/hooks/useMessages.test.ts
@@ -94,7 +94,7 @@ describe("useMessages", () => {
     });
 
     expect(result.current.messages).toEqual([]);
-    expect(sessionStorage.getItem("test_key")).toBe("[]");
+    expect(sessionStorage.getItem("test_key")).toBeNull();
   });
 
   it("clearMessages without a storageKey only resets state", () => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Infrastructure
- [ ] Maintenance

## Description

Add persistence for chat page and letter page message history using sessionStorage. Different storage keys for different jurisdictions.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note on the devices and browsers this has been tested on, as well as any relevant images for UI changes._


## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## Documentation

- [X] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?
