### PR TITLE
no longer holding svglib back since 2.x does not require (py)cairo

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -90,4 +90,7 @@ show_missing = true
 
 [tool.uv]
 exclude-newer = "1 week"
-exclude-newer-package = { langsmith = "4 days", svglib = "4 days" }  # TODO: both exceptions can be removed after 2026-06-28 (langsmith 0.8.18 release, svglib 2.0.2 release)
+
+[tool.uv.exclude-newer-package]
+langsmith = "4 days"  # TODO: remove after 2026-06-28 (langsmith 0.8.18 release)
+svglib = "4 days"  # TODO: remove after 2026-06-28 (svglib 2.0.2 release)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "flask-cors>=4.0.0",
   "xhtml2pdf>=0.2.17",
   "gunicorn>=23.0.0",
-  "svglib<1.6", # holding version back because 1.6.0 now requires manual platform installation of https://www.cairographics.org/download/
+  "svglib>=2.0.2",
   "python-dotenv",
   "langchain>=1.2.10,<2.0.0",
   "langchain-core>=1.2.11",
@@ -90,4 +90,4 @@ show_missing = true
 
 [tool.uv]
 exclude-newer = "1 week"
-exclude-newer-package = { langsmith = "4 days" }  # TODO: this exception can be removed after 2026-06-28 (langsmith 0.8.18 release)
+exclude-newer-package = { langsmith = "4 days", svglib = "4 days" }  # TODO: both exceptions can be removed after 2026-06-28 (langsmith 0.8.18 release, svglib 2.0.2 release)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -15,6 +15,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
+svglib = { timestamp = "0001-01-01T00:00:00Z", span = "P4D" }
 langsmith = { timestamp = "0001-01-01T00:00:00Z", span = "P4D" }
 
 [[package]]
@@ -3267,15 +3268,19 @@ wheels = [
 
 [[package]]
 name = "svglib"
-version = "1.5.1"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cssselect2" },
     { name = "lxml" },
+    { name = "pillow" },
     { name = "reportlab" },
     { name = "tinycss2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/5b/53ca0fd447f73423c7dc59d34e523530ef434481a3d18808ff7537ad33ec/svglib-1.5.1.tar.gz", hash = "sha256:3ae765d3a9409ee60c0fb4d24c2deb6a80617aa927054f5bcd7fc98f0695e587", size = 913900, upload-time = "2023-01-07T14:11:52.99Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/1f/e9dc8f16a834b6b0d5d7c0c20faeca614bcb31cbe67c54f61e3258978289/svglib-2.0.2.tar.gz", hash = "sha256:455e473dbe7066eea55c39de8194a6a3b646b6c37a255700257fd32115ddb218", size = 1341040, upload-time = "2026-06-18T07:12:50.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/de/eb6e07fb9fedba56921f8aa1dde4f5763b7abef1f962e6fea56a99092118/svglib-2.0.2-py3-none-any.whl", hash = "sha256:0fd04f1eb593802060427d6a59ab5127d65db6b8f5750d572f7df25097e36503", size = 45730, upload-time = "2026-06-18T07:12:49.221Z" },
+]
 
 [[package]]
 name = "tenacity"
@@ -3353,7 +3358,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.0.10" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "python-dotenv" },
-    { name = "svglib", specifier = "<1.6" },
+    { name = "svglib", specifier = ">=2.0.2" },
     { name = "xhtml2pdf", specifier = ">=0.2.17" },
 ]
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Infrastructure
- [x] Maintenance

## Description

Previously we were holding back `svglib` to 1.5.x because 1.6.x depended on (py)cairo (and that wasn't installed on the DO Droplet).  `svglib` 2.x has dropped that dependency.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note on the devices and browsers this has been tested on, as well as any relevant images for UI changes._


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: dependency bump
- [ ] I need help with writing tests

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?
