### PR TITLE
Encode state-level city metadata as "null" string

### DIFF
--- a/backend/scripts/generate_metadata_jsonl.py
+++ b/backend/scripts/generate_metadata_jsonl.py
@@ -68,7 +68,10 @@ def build_entries(documents_dir: Path, bucket: str, scopes: set[str]) -> list[Do
         entries.append(
             Document(
                 id=txt_file.stem,
-                struct_data={"city": city, "state": "or"},
+                # State-level docs use the literal string "null" (not JSON null,
+                # which Vertex drops on import) so the retriever's city: ANY("null")
+                # filter matches them.
+                struct_data={"city": city if city is not None else "null", "state": "or"},
                 content=Document.Content(
                     mime_type="text/plain",
                     uri=f"gs://{bucket}/{txt_file.name}",

--- a/backend/scripts/generate_metadata_jsonl.py
+++ b/backend/scripts/generate_metadata_jsonl.py
@@ -71,7 +71,10 @@ def build_entries(documents_dir: Path, bucket: str, scopes: set[str]) -> list[Do
                 # State-level docs use the literal string "null" (not JSON null,
                 # which Vertex drops on import) so the retriever's city: ANY("null")
                 # filter matches them.
-                struct_data={"city": city if city is not None else "null", "state": "or"},
+                struct_data={
+                    "city": city if city is not None else "null",
+                    "state": "or",
+                },
                 content=Document.Content(
                     mime_type="text/plain",
                     uri=f"gs://{bucket}/{txt_file.name}",

--- a/backend/tests/test_generate_metadata_jsonl.py
+++ b/backend/tests/test_generate_metadata_jsonl.py
@@ -58,7 +58,7 @@ class TestBuildEntries:
         entries = build_entries(doc_tree, "my-bucket", {"or"})
         entry = entries[0]
         assert entry.id == "ORS090"
-        assert entry.struct_data == {"city": None, "state": "or"}
+        assert entry.struct_data == {"city": "null", "state": "or"}
         assert entry.content.mime_type == "text/plain"
         assert entry.content.uri == "gs://my-bucket/ORS090.txt"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Vertex AI Search drops `struct_data` fields whose value is JSON `null` on import. State-level law docs were generated with `{"city": null}`, so they landed in the datastore with no `city` field at all. The retriever filters those docs with `city: ANY("null")`, which matches the literal string `"null"` — not a missing field — so state-level statutes (ORS 90, 91, 105, etc.) returned zero results.

This emits the literal string `"null"` for state-level docs instead of JSON `null`, so the metadata matches the filter.

Note: this fixes the generator for future corpus builds. The currently-affected datastore (`city-state-law-search-05082026-edition`) was already repaired in place by patching its bucket `metadata.jsonl` and re-importing.

## Related Tickets & Documents

- Related Issue #276

## QA Instructions, Screenshots, Recordings

`cd backend && uv run pytest tests/test_generate_metadata_jsonl.py` — all pass. State-level entries now serialize as `{"city": "null", "state": "or"}`.

## Added/updated tests?

- [x] Yes

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated
