### PR TITLE
use `extractive_segments` and also generate markdown from traces

### DIFF
--- a/backend/evaluate/langsmith_dataset.py
+++ b/backend/evaluate/langsmith_dataset.py
@@ -13,6 +13,7 @@ Usage examples:
     experiment list my-dataset
     experiment show <name-or-uuid>
     experiment stats <name-or-uuid>
+    experiment markdown <name-or-uuid> ./traces.md
     runs exemplars <name-or-uuid> <scenario-id> --evaluator "legal correctness"
     runs show <run-id>
     runs trace <run-id>
@@ -32,6 +33,7 @@ import subprocess
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Literal
 
@@ -59,6 +61,10 @@ EVALUATE_DIR = Path(__file__).parent
 DEFAULT_SCHEMA = EVALUATE_DIR / "langsmith_example_schema.json"
 DEFAULT_DATASET_NAME = "tenant-legal-qa-scenarios"
 DEFAULT_JSONL = EVALUATE_DIR / "dataset-tenant-legal-qa-examples.jsonl"
+
+# LangSmith's default trace retention; queries reaching further back return
+# nothing older than this because expired traces are already purged.
+RETENTION_DAYS = 14
 
 
 @dataclass(frozen=True)
@@ -530,6 +536,178 @@ def cmd_example_update(args: argparse.Namespace) -> None:
 
 
 # ── experiment subcommands ─────────────────────────────────────────────────────
+
+
+def _message_text(content: Any) -> str:
+    """Extract human-readable text from a chat message 'content' field.
+
+    Content may be a plain string or a list of content blocks.  Only text
+    blocks are kept, so reasoning signatures and other structured payloads are
+    dropped.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                if block.get("text"):
+                    parts.append(block["text"])
+        return "\n".join(parts)
+    return ""
+
+
+_TRANSCRIPT_ROLES = {"human": "User", "ai": "Assistant"}
+
+
+def _render_transcript(messages: Any) -> str:
+    """Render a chat message list as a blockquoted User/Assistant transcript.
+
+    Internal tool (RAG retrieval) and system messages are dropped so only the
+    human/assistant conversation remains.  Each turn is a markdown blockquote
+    with a bold role label; turns are separated by a blank quote line.
+    """
+    blocks = []
+    for m in messages or []:
+        label = _TRANSCRIPT_ROLES.get(m.get("role") or m.get("type"))
+        if label is None:
+            continue
+        text = _message_text(m.get("content")).strip()
+        if not text:
+            continue
+        body = f"**{label}:** {text}"
+        blocks.append("\n".join("> " + line for line in body.splitlines()))
+    return "\n>\n".join(blocks)
+
+
+# Registry of PII checks for exported transcripts. Each entry maps a category
+# name to a compiled pattern; add a new check by appending one line here and
+# _scan_pii picks it up automatically. Matching is intentionally broad — this
+# is a warn-only safety net, not a redactor, so false positives are acceptable.
+_PII_PATTERNS: dict[str, re.Pattern] = {
+    "email": re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"),
+    "phone": re.compile(r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}\b"),
+    "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+    "street_address": re.compile(
+        r"\b\d{1,6}\s+(?:[A-Za-z]+\s){0,3}"
+        r"(?:Street|St|Avenue|Ave|Boulevard|Blvd|Road|Rd|Drive|Dr|Lane|Ln|"
+        r"Court|Ct|Way|Place|Pl|Terrace|Ter|Circle|Cir)\b",
+        re.IGNORECASE,
+    ),
+    "po_box": re.compile(r"\bP\.?\s?O\.?\s?Box\s+\d+\b", re.IGNORECASE),
+    "credit_card": re.compile(r"\b(?:\d[ -]?){13,16}\b"),
+    "ip_address": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
+}
+
+
+def _scan_pii(text: str) -> dict[str, list[str]]:
+    """Return {category: sorted unique matches} for every PII pattern that hits.
+
+    Categories with no matches are omitted. Extend _PII_PATTERNS to add checks.
+    """
+    findings: dict[str, list[str]] = {}
+    for label, pattern in _PII_PATTERNS.items():
+        matches = sorted(
+            {m if isinstance(m, str) else m[0] for m in pattern.findall(text)}
+        )
+        if matches:
+            findings[label] = matches
+    return findings
+
+
+def _warn_pii(findings: dict[str, list[str]], path: Path) -> None:
+    """Print a stderr summary of detected PII. Warn-only; never raises or blocks."""
+    if not findings:
+        return
+    total = sum(len(v) for v in findings.values())
+    print(
+        f"warning: {path.name} may contain PII ({total} potential match(es)); "
+        "review before sharing or committing:",
+        file=sys.stderr,
+    )
+    for label, matches in findings.items():
+        preview = ", ".join(matches[:5])
+        more = f" (+{len(matches) - 5} more)" if len(matches) > 5 else ""
+        print(f"  {label}: {len(matches)} unique — {preview}{more}", file=sys.stderr)
+
+
+def cmd_experiment_markdown(args: argparse.Namespace) -> None:
+    """Export an experiment/project's root-run conversations to a markdown file.
+
+    Reads every root run (execution_order=1) of the named project, the same way
+    'experiment results' does, and renders each run's input messages as a
+    human-readable User/Assistant transcript with its city/state.
+    """
+    local: Path = args.file
+
+    if local.exists() and not args.force and not _git_is_clean(local):
+        print(
+            f"error: {local.name} has uncommitted changes. Commit first or pass --force.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Bound the query to the requested window. Reaching past the retention
+    # ceiling can't surface older traces, so clamp and warn rather than imply
+    # the extra days returned anything.
+    days = args.days
+    if days > RETENTION_DAYS:
+        print(
+            f"warning: --days {days} exceeds the {RETENTION_DAYS}-day LangSmith "
+            f"retention window; clamping to {RETENTION_DAYS}.",
+            file=sys.stderr,
+        )
+        days = RETENTION_DAYS
+    start_time = datetime.now(timezone.utc) - timedelta(days=days)
+
+    client = make_client()
+    p = _read_project(client, args.experiment)
+    runs = sorted(
+        client.list_runs(project_id=p.id, execution_order=1, start_time=start_time),
+        key=lambda r: r.start_time or datetime.min,
+    )
+
+    lines = [
+        f"# Traces from `{p.name}`",
+        "",
+        f"Project ID: `{p.id}`  ",
+        f"Window: last {days} days (since {start_time.isoformat()})  ",
+        f"Total examples: {len(runs)}",
+        "",
+        "---",
+        "",
+    ]
+    for i, run in enumerate(runs, 1):
+        inputs = run.inputs or {}
+        lines += [
+            f"## Example {i}",
+            "",
+            f"- **city:** `{inputs.get('city')}`",
+            f"- **state:** `{inputs.get('state')}`",
+            f"- **run id:** `{run.id}`",
+            f"- **time:** {run.start_time.isoformat() if run.start_time else '?'}",
+            "",
+            "**script:**",
+            "",
+            _render_transcript(inputs.get("messages")),
+            "",
+            "---",
+            "",
+        ]
+
+    document = "\n".join(lines)
+    # Warn-only PII scan: these are real production conversations, so flag
+    # likely PII before the file is shared or committed, but never block.
+    _warn_pii(_scan_pii(document), local)
+
+    if args.dry_run:
+        print(f"Would write {len(runs)} examples from '{p.name}' to {local}.")
+        return
+
+    local.write_text(document)
+    print(f"Wrote {len(runs)} examples from '{p.name}' to {local}.")
 
 
 def cmd_experiment_list(args: argparse.Namespace) -> None:
@@ -1311,6 +1489,50 @@ def build_parser() -> argparse.ArgumentParser:
         "experiment", metavar="name-or-uuid", help="LangSmith experiment name or UUID."
     )
     p.set_defaults(func=cmd_experiment_results)
+
+    p = ex_sub.add_parser(
+        "markdown",
+        help="Export root-run conversations to a human-readable markdown file.",
+        description=(
+            "Render every root run of an experiment or tracing project as a "
+            "human-readable User/Assistant transcript, with each run's city and "
+            "state. Internal tool (RAG retrieval) and system messages are dropped. "
+            "Useful for reviewing production traces before turning them into "
+            "evaluation examples."
+        ),
+    )
+    p.add_argument(
+        "experiment",
+        metavar="name-or-uuid",
+        help="LangSmith experiment or tracing project name or UUID.",
+    )
+    p.add_argument(
+        "file", type=Path, metavar="file.md", help="Local markdown file to write."
+    )
+    p.add_argument(
+        "--days",
+        type=int,
+        default=14,
+        metavar="N",
+        help=(
+            "Only include runs from the last N days (default: 14, the LangSmith "
+            "default retention window). Shrink for a more recent slice; values "
+            "above 14 are clamped since older traces are already purged."
+        ),
+    )
+    p.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Overwrite local file even if it has uncommitted changes.",
+    )
+    p.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Show what would be written without writing the file.",
+    )
+    p.set_defaults(func=cmd_experiment_markdown)
 
     p = ex_sub.add_parser(
         "stats",

--- a/backend/evaluate/langsmith_dataset.py
+++ b/backend/evaluate/langsmith_dataset.py
@@ -666,7 +666,7 @@ def cmd_experiment_markdown(args: argparse.Namespace) -> None:
     p = _read_project(client, args.experiment)
     runs = sorted(
         client.list_runs(project_id=p.id, execution_order=1, start_time=start_time),
-        key=lambda r: r.start_time or datetime.min,
+        key=lambda r: r.start_time or datetime.min.replace(tzinfo=timezone.utc),
     )
 
     lines = [
@@ -689,7 +689,7 @@ def cmd_experiment_markdown(args: argparse.Namespace) -> None:
             f"- **run id:** `{run.id}`",
             f"- **time:** {run.start_time.isoformat() if run.start_time else '?'}",
             "",
-            "**script:**",
+            "**transcript:**",
             "",
             _render_transcript(inputs.get("messages")),
             "",
@@ -1512,12 +1512,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--days",
         type=int,
-        default=14,
+        default=RETENTION_DAYS,
         metavar="N",
         help=(
-            "Only include runs from the last N days (default: 14, the LangSmith "
+            f"Only include runs from the last N days (default: {RETENTION_DAYS}, the LangSmith "
             "default retention window). Shrink for a more recent slice; values "
-            "above 14 are clamped since older traces are already purged."
+            f"above {RETENTION_DAYS} are clamped since older traces are already purged."
         ),
     )
     p.add_argument(

--- a/backend/tenantfirstaid/langchain_tools.py
+++ b/backend/tenantfirstaid/langchain_tools.py
@@ -82,6 +82,10 @@ class RagBuilder:
         filter: Optional[str] = None,
         max_documents: int = 3,
         *,
+        # Retained as an ad-hoc escape hatch: _make_rag_tool never sets
+        # get_extractive_answers=True, so these two knobs are effectively
+        # dormant in production. Flip get_extractive_answers=True in a
+        # one-off RagBuilder call to experiment with answer-mode retrieval.
         get_extractive_answers: bool = False,
         max_extractive_answer_count: int = 1,
         max_extractive_segment_count: int = 3,

--- a/backend/tenantfirstaid/langchain_tools.py
+++ b/backend/tenantfirstaid/langchain_tools.py
@@ -81,6 +81,10 @@ class RagBuilder:
         name: Optional[str] = "tfa-retriever",
         filter: Optional[str] = None,
         max_documents: int = 3,
+        *,
+        get_extractive_answers: bool = False,
+        max_extractive_answer_count: int = 1,
+        max_extractive_segment_count: int = 3,
     ) -> None:
         if SINGLETON.GOOGLE_APPLICATION_CREDENTIALS is None:
             raise ValueError("GOOGLE_APPLICATION_CREDENTIALS is not set")
@@ -96,7 +100,16 @@ class RagBuilder:
             location_id=SINGLETON.GOOGLE_CLOUD_LOCATION,
             data_store_id=data_store_id,
             engine_data_type=0,  # 0 = unstructured; all TFA datastores are unstructured docs
-            get_extractive_answers=True,  # TODO: figure out if this is useful
+            # Default to extractive segments rather than answers. Extractive answers
+            # are short, individually selected sentences that, for statutory queries,
+            # tend to surface annotation/case-note lines that lexically match the
+            # query (e.g. "duty to mitigate damages" from NOTES OF DECISIONS) while
+            # the operative statutory text — which lives in longer segments — is
+            # never returned. Segments return the surrounding block, so the citable
+            # subsection text (e.g. ORS 90.410(3), ORS 90.302(2)(e)) comes through.
+            get_extractive_answers=get_extractive_answers,
+            max_extractive_answer_count=max_extractive_answer_count,
+            max_extractive_segment_count=max_extractive_segment_count,
             # Suggestion-only: spell corrections are recorded in the response but the
             # original query is used for retrieval. Prevents auto-correction from
             # mangling ORS references and other legal terminology.
@@ -217,7 +230,13 @@ class CityStateLawsInputSchema(BaseModel):
     state: UsaState
     city: Optional[OregonCity] = None
     max_documents: int = Field(
-        default=5,
+        # A truncation analysis over the extractive-segments-dfe32555 experiment
+        # (36 real agent queries) found every meaningful statute that production
+        # retrieved at md=5 was also present at doc-rank <=3 — ranks 4-5 were
+        # always redundant duplicates. Defaulting to 3 cuts the retrieval payload
+        # ~40% with zero observed truncation. (Reducing segments below 3, by
+        # contrast, did truncate ~14% of queries, so that knob is left at 3.)
+        default=3,
         ge=1,
         le=8,  # Total number of documents in the laws datastore.
         description="""Number of passages to retrieve (1–8). Use a smaller value
@@ -226,25 +245,16 @@ class CityStateLawsInputSchema(BaseModel):
                        statutes, involves city overrides, or an initial retrieval
                        missed the relevant passage.""",
     )
-    max_extractive_answer_count: int = Field(
-        default=1,
-        ge=1,
-        le=5,
-        description="""Extractive answers per document (1–5). Each is a short
-                       passage the search engine identifies as directly relevant.
-                       Increase on retry if the first search returned passages
-                       from the right document but missed the specific subsection
-                       you need.""",
-    )
     max_extractive_segment_count: int = Field(
         default=3,
         ge=1,
         le=10,
         description="""Extractive segments per document (1–10). Segments are
-                       longer surrounding blocks of text that provide more context
-                       than answers. Increase on retry when the answer likely sits
-                       adjacent to what was returned (e.g. the right ORS section
-                       was found but a neighboring subsection was missed).""",
+                       blocks of statutory text returned with their surrounding
+                       context — this is how the operative subsection text (e.g. a
+                       specific ORS paragraph) is surfaced. Increase on retry when
+                       the right ORS section was found but the specific subsection
+                       you need sits adjacent to what was returned.""",
     )
 
 
@@ -282,11 +292,21 @@ def _make_rag_tool(
         schema_data = {k: v for k, v in kwargs.items() if k in args_schema.model_fields}
         validated = args_schema.model_validate(schema_data).model_dump()
         rag_filter = filter_builder(**validated) if filter_builder is not None else None
+        # Forward extractive-count knobs when the schema exposes them. These were
+        # previously validated but silently dropped, so the model's documented
+        # "increase on retry" guidance had no effect. RagBuilder defaults cover
+        # schemas that omit them (e.g. QueryOnlyInputSchema).
+        extractive_kwargs = {
+            k: validated[k]
+            for k in ("max_extractive_answer_count", "max_extractive_segment_count")
+            if k in validated
+        }
         helper = RagBuilder(
             data_store_id=SINGLETON.VERTEX_AI_DATASTORES[datastore_key],
             name=tool_name,
             filter=rag_filter,
             max_documents=validated["max_documents"],
+            **extractive_kwargs,
         )
         return helper.search(query=validated["query"])
 

--- a/backend/tests/test_langchain_tools.py
+++ b/backend/tests/test_langchain_tools.py
@@ -319,15 +319,15 @@ def test_make_rag_tool_custom_filter_builder(mock_rag_class):
         query="test query",
         state=UsaState("or"),
         city=None,
-        max_documents=5,
-        max_extractive_answer_count=1,
+        max_documents=3,
         max_extractive_segment_count=3,
     )
     mock_rag_class.assert_called_once_with(
         data_store_id="fake-id",
         name="test_tool",
         filter="custom-filter",
-        max_documents=5,
+        max_documents=3,
+        max_extractive_segment_count=3,
     )
 
 

--- a/backend/tests/test_langsmith_dataset.py
+++ b/backend/tests/test_langsmith_dataset.py
@@ -1,6 +1,7 @@
 """Tests for evaluate/langsmith_dataset.py."""
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -10,6 +11,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from evaluate.langsmith_dataset import (
+    RETENTION_DAYS,
     _apply_dataset_schemas,
     _example_content_diff,
     _experiment_scores,
@@ -17,10 +19,14 @@ from evaluate.langsmith_dataset import (
     _git_is_clean,
     _load_dataset_schemas,
     _load_examples,
+    _message_text,
     _read_jsonl,
+    _render_transcript,
+    _scan_pii,
     _scenario_id,
     _tabulate,
     _Validate,
+    _warn_pii,
     build_parser,
     cmd_dataset_create,
     cmd_dataset_delete,
@@ -36,6 +42,7 @@ from evaluate.langsmith_dataset import (
     cmd_example_show,
     cmd_example_update,
     cmd_experiment_compare,
+    cmd_experiment_markdown,
     cmd_experiment_show,
     cmd_experiment_stats,
     cmd_run_exemplars,
@@ -1717,3 +1724,290 @@ def test_cmd_run_trace_verbose_recurses_into_child_runs(capsys):
     assert "parent-chain" in out
     assert "child-tool" in out
     assert "child input" in out
+
+
+# ── _message_text ──────────────────────────────────────────────────────────────
+
+
+def test_message_text_plain_string():
+    assert _message_text("hello") == "hello"
+
+
+def test_message_text_joins_text_blocks():
+    content = [{"type": "text", "text": "one"}, {"type": "text", "text": "two"}]
+    assert _message_text(content) == "one\ntwo"
+
+
+def test_message_text_drops_non_text_blocks():
+    # Reasoning signatures and other structured payloads carry no "text" type.
+    content = [
+        {"type": "reasoning", "signature": "abc"},
+        {"type": "text", "text": "kept"},
+    ]
+    assert _message_text(content) == "kept"
+
+
+def test_message_text_non_string_non_list_returns_empty():
+    assert _message_text(None) == ""
+    assert _message_text({"type": "text", "text": "x"}) == ""
+
+
+# ── _render_transcript ─────────────────────────────────────────────────────────
+
+
+def test_render_transcript_bolds_roles():
+    messages = [
+        {"role": "human", "content": "hi"},
+        {"role": "ai", "content": "hello"},
+    ]
+    out = _render_transcript(messages)
+    assert "> **User:** hi" in out
+    assert "> **Assistant:** hello" in out
+
+
+def test_render_transcript_drops_tool_and_system_messages():
+    messages = [
+        {"role": "human", "content": "q"},
+        {"role": "tool", "content": "RAG retrieval dump"},
+        {"role": "system", "content": "you are a bot"},
+        {"role": "ai", "content": "a"},
+    ]
+    out = _render_transcript(messages)
+    assert "RAG retrieval dump" not in out
+    assert "you are a bot" not in out
+    assert "**User:** q" in out
+    assert "**Assistant:** a" in out
+
+
+def test_render_transcript_reads_type_key():
+    # LangChain-serialised messages use "type" rather than "role".
+    messages = [{"type": "human", "content": "hi"}]
+    assert "> **User:** hi" in _render_transcript(messages)
+
+
+def test_render_transcript_skips_empty_content():
+    messages = [
+        {"role": "human", "content": ""},
+        {"role": "ai", "content": "only this"},
+    ]
+    out = _render_transcript(messages)
+    assert "only this" in out
+    assert "**User:**" not in out
+
+
+def test_render_transcript_quotes_every_line():
+    messages = [{"role": "ai", "content": "line1\nline2"}]
+    out = _render_transcript(messages)
+    assert "> **Assistant:** line1" in out
+    assert "> line2" in out
+
+
+def test_render_transcript_empty_messages():
+    assert _render_transcript([]) == ""
+    assert _render_transcript(None) == ""
+
+
+# ── cmd_experiment_markdown ────────────────────────────────────────────────────
+
+
+def _make_md_run(messages, city=None, state="or", start_time=None):
+    r = MagicMock()
+    r.id = uuid4()
+    r.inputs = {"city": city, "state": state, "messages": messages}
+    r.start_time = start_time or datetime(2026, 6, 20, tzinfo=timezone.utc)
+    return r
+
+
+def _md_args(file, *, days=RETENTION_DAYS, force=False, dry_run=False):
+    return MagicMock(
+        experiment="tenantfirstaid-prod",
+        file=file,
+        days=days,
+        force=force,
+        dry_run=dry_run,
+    )
+
+
+def _md_client(runs):
+    client = MagicMock()
+    client.read_project.return_value = _make_project("tenantfirstaid-prod", "proj-1")
+    client.list_runs.return_value = runs
+    return client
+
+
+def test_cmd_experiment_markdown_writes_transcript(tmp_path):
+    out = tmp_path / "traces.md"
+    runs = [
+        _make_md_run(
+            [{"role": "human", "content": "Can I be evicted?"}],
+            city="portland",
+            state="or",
+        )
+    ]
+    with patch("evaluate.langsmith_dataset.make_client", return_value=_md_client(runs)):
+        cmd_experiment_markdown(_md_args(out))
+
+    text = out.read_text()
+    assert "# Traces from `tenantfirstaid-prod`" in text
+    assert "## Example 1" in text
+    assert "- **city:** `portland`" in text
+    assert "- **state:** `or`" in text
+    assert "> **User:** Can I be evicted?" in text
+
+
+def test_cmd_experiment_markdown_drops_tool_messages(tmp_path):
+    out = tmp_path / "traces.md"
+    runs = [
+        _make_md_run(
+            [
+                {"role": "human", "content": "q"},
+                {"role": "tool", "content": "internal RAG payload"},
+                {"role": "ai", "content": "a"},
+            ]
+        )
+    ]
+    with patch("evaluate.langsmith_dataset.make_client", return_value=_md_client(runs)):
+        cmd_experiment_markdown(_md_args(out))
+
+    assert "internal RAG payload" not in out.read_text()
+
+
+def test_cmd_experiment_markdown_dry_run_does_not_write(tmp_path, capsys):
+    out = tmp_path / "traces.md"
+    runs = [_make_md_run([{"role": "human", "content": "q"}])]
+    with patch("evaluate.langsmith_dataset.make_client", return_value=_md_client(runs)):
+        cmd_experiment_markdown(_md_args(out, dry_run=True))
+
+    assert not out.exists()
+    assert "Would write 1 examples" in capsys.readouterr().out
+
+
+def test_cmd_experiment_markdown_respects_days(tmp_path):
+    out = tmp_path / "traces.md"
+    client = _md_client([_make_md_run([{"role": "human", "content": "q"}])])
+    with patch("evaluate.langsmith_dataset.make_client", return_value=client):
+        cmd_experiment_markdown(_md_args(out, days=3))
+
+    start_time = client.list_runs.call_args.kwargs["start_time"]
+    expected = datetime.now(timezone.utc) - timedelta(days=3)
+    assert abs((expected - start_time).total_seconds()) < 60
+    assert "Window: last 3 days" in out.read_text()
+
+
+def test_cmd_experiment_markdown_clamps_and_warns(tmp_path, capsys):
+    out = tmp_path / "traces.md"
+    client = _md_client([_make_md_run([{"role": "human", "content": "q"}])])
+    with patch("evaluate.langsmith_dataset.make_client", return_value=client):
+        cmd_experiment_markdown(_md_args(out, days=30))
+
+    err = capsys.readouterr().err
+    assert "exceeds" in err
+    assert f"clamping to {RETENTION_DAYS}" in err
+
+    start_time = client.list_runs.call_args.kwargs["start_time"]
+    expected = datetime.now(timezone.utc) - timedelta(days=RETENTION_DAYS)
+    assert abs((expected - start_time).total_seconds()) < 60
+    assert f"Window: last {RETENTION_DAYS} days" in out.read_text()
+
+
+def test_cmd_experiment_markdown_aborts_on_dirty_file(tmp_path, capsys):
+    out = tmp_path / "traces.md"
+    out.write_text("existing")
+    with patch("evaluate.langsmith_dataset._git_is_clean", return_value=False):
+        with pytest.raises(SystemExit):
+            cmd_experiment_markdown(_md_args(out))
+
+    assert "uncommitted changes" in capsys.readouterr().err
+    assert out.read_text() == "existing"
+
+
+def test_cmd_experiment_markdown_force_overwrites_dirty_file(tmp_path):
+    out = tmp_path / "traces.md"
+    out.write_text("existing")
+    runs = [_make_md_run([{"role": "human", "content": "fresh"}])]
+    with (
+        patch("evaluate.langsmith_dataset._git_is_clean", return_value=False),
+        patch("evaluate.langsmith_dataset.make_client", return_value=_md_client(runs)),
+    ):
+        cmd_experiment_markdown(_md_args(out, force=True))
+
+    assert "fresh" in out.read_text()
+
+
+# ── _scan_pii / _warn_pii ──────────────────────────────────────────────────────
+
+
+def test_scan_pii_detects_common_categories():
+    text = (
+        "Reach me at jane.doe@example.com or 503-555-0142. "
+        "SSN 123-45-6789, I live at 4220 SE Belmont Street."
+    )
+    findings = _scan_pii(text)
+    assert findings["email"] == ["jane.doe@example.com"]
+    assert findings["ssn"] == ["123-45-6789"]
+    assert "phone" in findings
+    assert "street_address" in findings
+
+
+def test_scan_pii_clean_text_returns_empty():
+    assert _scan_pii("Under ORS 90.427 a landlord must give notice.") == {}
+
+
+def test_scan_pii_dedupes_matches():
+    text = "a@b.com then again a@b.com"
+    assert _scan_pii(text)["email"] == ["a@b.com"]
+
+
+def test_scan_pii_picks_up_new_registry_entries():
+    # New checks are added by extending the registry; _scan_pii should use them.
+    import re as _re
+
+    from evaluate import langsmith_dataset as mod
+
+    with patch.dict(
+        mod._PII_PATTERNS, {"zip5": _re.compile(r"\b\d{5}\b")}, clear=False
+    ):
+        assert _scan_pii("Portland 97214")["zip5"] == ["97214"]
+
+
+def test_warn_pii_silent_when_no_findings(capsys):
+    _warn_pii({}, Path("out.md"))
+    assert capsys.readouterr().err == ""
+
+
+def test_warn_pii_summarizes_findings(capsys):
+    _warn_pii({"email": ["a@b.com", "c@d.com"]}, Path("out.md"))
+    err = capsys.readouterr().err
+    assert "out.md may contain PII" in err
+    assert "email: 2 unique" in err
+
+
+def test_warn_pii_truncates_long_match_lists(capsys):
+    emails = [f"user{i}@example.com" for i in range(8)]
+    _warn_pii({"email": emails}, Path("out.md"))
+    err = capsys.readouterr().err
+    assert "(+3 more)" in err
+
+
+def test_cmd_experiment_markdown_warns_on_pii(tmp_path, capsys):
+    out = tmp_path / "traces.md"
+    runs = [
+        _make_md_run([{"role": "human", "content": "Email me at tenant@example.com"}])
+    ]
+    with patch("evaluate.langsmith_dataset.make_client", return_value=_md_client(runs)):
+        cmd_experiment_markdown(_md_args(out))
+
+    err = capsys.readouterr().err
+    assert "may contain PII" in err
+    assert "tenant@example.com" in err
+    # Warn-only: the file is still written.
+    assert out.exists()
+
+
+def test_cmd_experiment_markdown_no_pii_warning_when_clean(tmp_path, capsys):
+    out = tmp_path / "traces.md"
+    runs = [_make_md_run([{"role": "human", "content": "Can I be evicted?"}])]
+    with patch("evaluate.langsmith_dataset.make_client", return_value=_md_client(runs)):
+        cmd_experiment_markdown(_md_args(out))
+
+    assert "may contain PII" not in capsys.readouterr().err


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Infrastructure
- [ ] Maintenance

## Description

1. switch from _extractive_answers_ to _extractive_segments_
2. add a subcmd to `langsmith_dataset` to generate a human-readable markdown file from a set of traces (like the ones collected by #371)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note on the devices and browsers this has been tested on, as well as any relevant images for UI changes._


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?
