### PR TITLE
add Optimize-experiment skill for Claude

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -32,4 +32,5 @@ Load these on demand -- don't include their content in every response, just invo
 | `/frontend` | Working on frontend code (commands, type generation, Docker) |
 | `/corpus-dataset` | Adding, modifying, or reviewing `.txt` law files in `backend/scripts/documents/` (includes ASCII enforcement rules) |
 | `/evaluation` | Running, analyzing, or improving LangSmith evaluations |
+| `/optimize-experiment` | Reducing token usage and latency once quality scores are stable |
 | `/pr` | Writing commit messages, opening PRs, or reviewing code |

--- a/.claude/skills/evaluation.md
+++ b/.claude/skills/evaluation.md
@@ -152,6 +152,10 @@ To detect a 0.10-point improvement with 80% power, you need ~32 repetitions per 
 
 Use `/analyze-experiment <experiment-name-or-uuid>` for automated root-cause diagnosis — it runs the full trace investigation workflow and recommends fixes matched to the failure mode (retrieval miss, query too broad, reasoning failure, instruction conflict, confabulation, misleading retrieval).
 
+## Optimizing a stable system
+
+Use `/optimize-experiment <experiment-name-or-uuid>` once scores are stable and the goal shifts from fixing failures to reducing cost and latency. Three targets: (1) L1/L2 corpus and retrieval improvements that eliminate the need for STOPGAPs; (2) L3 system-prompt size reduction — retiring STOPGAPs whose corpus gaps are fixed, pruning Clarifications that are no longer load-bearing; (3) retrieval parameter tuning — finding the minimum docs×segments that preserves coverage. Do not use this skill while actively investigating failures — fix quality first, then optimize.
+
 ---
 
 ## Editing the system prompt

--- a/.claude/skills/optimize-experiment/SKILL.md
+++ b/.claude/skills/optimize-experiment/SKILL.md
@@ -1,0 +1,78 @@
+# Optimize Experiment
+
+Reduce system-prompt token usage and retrieval latency without regressing quality scores. Run this after scores are stable — not during active failure investigation.
+
+The argument is a recent passing experiment to use as a baseline (e.g. `/optimize-experiment extractive-segments-plus-clarifications-IV-83bcb22b`).
+
+There are three optimization targets, ordered by impact. Each targets a different layer of the defense-in-depth stack (see [[defense-in-depth-retrieval-reasoning]]).
+
+---
+
+## Use case 1 — L1/L2 corpus and retrieval improvements
+
+The highest-leverage optimization: fix retrieval gaps at the data-store level so STOPGAPs (L3 compensations) become unnecessary. Every STOPGAP removed reduces tokens on every request.
+
+**L1 — Section-aware chunking:** the current retrieval failures for ORS 90.325 (0/4) and ORS 90.425 (2/4) are chunking problems — the operative subsection lands in a different chunk from the query-attracting catchline. The fix is to reindex with section-boundary-aware chunks that keep each ORS section's catchline + operative subsections together. See GitHub issue #372.
+
+**L2b — Citation-graph follower node:** a LangGraph node that scans retrieved text for embedded ORS citations and eagerly fetches cited sections in parallel. Addresses cross-section reference gaps without adding system-prompt entries. Not yet implemented — see [[defense-in-depth-retrieval-reasoning]] Layer 2b.
+
+**How to measure L1/L2 impact:** `runs stopgap-check <experiment>` runs two checks in sequence:
+
+1. **L1/L2 trace check** (free — reads LangSmith trace data): for each STOPGAP, checks whether its verbatim target text appeared in the passages retrieved during the experiment. The sampling unit is the *repetition* (root run): a repetition counts as a hit if any of its RAG calls returned the target. The denominator is restricted to repetitions of examples whose `facts` mention that statute's ORS number, so it reflects only scenarios that actually exercise the statute. Reports one of: `retirement candidate` (hit in every relevant repetition), `partially retrieved`, or `never retrieved`. A STOPGAP that is doing its job by suppressing retrieval shows up as `no relevant scenarios found` (the model answered from the prompt and never called the tool) — that is a coverage gap, not a pass, and must be resolved with check #2.
+
+2. **Vertex AI re-query** (live retrieval calls): re-queries the *current* retrieval system with the real production queries from the experiment, reporting current hit rate. This only adds information when the datastore differs from the one the trace recorded, so it is **skipped automatically** unless one of these holds: the datastore was reindexed after the experiment ran (confirms the corpus fix is live), check #1 reported a coverage gap (so it can probe the retriever directly, bypassing the agent's decision not to retrieve), or you pass `--force-requery`. For an unchanged datastore that the experiment already exercised, check #1 alone is sufficient and the re-query would just reproduce the trace at the cost of live calls. The skip compares the datastore's last reindex time against the experiment's run time; if either can't be determined it falls open and re-queries.
+
+```bash
+cd backend
+# Against a recent experiment:
+uv run langsmith-dataset runs stopgap-check <baseline-experiment>
+
+# Ad-hoc (Vertex AI re-query only — no trace check):
+uv run langsmith-dataset runs stopgap-check \
+  --query "tenant liability for damages caused by domestic violence perpetrator" \
+  --query "landlord requirements for handling tenant abandoned personal property"
+```
+
+A STOPGAP showing `retirement candidate` in the trace check AND N/N in the Vertex AI re-query is ready for Use case 2.
+
+---
+
+## Use case 2 — L3 system-prompt size reduction
+
+**STOPGAP retirement:** after a corpus fix moves a STOPGAP's hit rate to N/N, remove the STOPGAP entry from `system_prompt.md`, run a new experiment, and confirm scores hold. If scores drop, the corpus fix hasn't fully landed — restore the STOPGAP.
+
+**Clarification pruning:** Clarifications that target a failure mode that hasn't appeared in the last 2–3 experiments at 10 repetitions may no longer be load-bearing (model update or improved retrieval resolved the gap). Remove or shorten the Clarification, run a new experiment, compare. There is no automated probe for this — a full experiment run is required.
+
+In both cases the test is the same: remove → run → compare to baseline → keep if scores hold, restore if they drop.
+
+---
+
+## Use case 3 — Retrieval parameter tuning
+
+The agent calls Vertex AI Search with `max_results` (documents) × `max_extractive_segment_count` (segments per document). The production default (3 × 3) was set empirically. Higher values improve recall but increase latency and the token volume the model processes.
+
+**How to find the minimum viable params:** use `shmoo` to sweep segment count for each STOPGAP scenario and find the threshold where its text first appears:
+
+```bash
+cd backend
+uv run python -m scripts.vertex_ai_search shmoo \
+  "<representative query>" \
+  --target "<verbatim phrase from STOPGAP>" \
+  --max-segment-sweep 10
+```
+
+Run this for each STOPGAP scenario. ORS 90.425 (2/4 at production params) may need more segments, not fewer — the shmoo sweep will show the crossover point. Only reduce params in scenarios where target text appears at segment counts below the current default.
+
+---
+
+## Running a new experiment
+
+```bash
+cd backend
+uv run run-langsmith-evaluation \
+  --dataset tenant-legal-qa-scenarios \
+  --experiment <descriptive-name> \
+  --num-repetitions 10
+```
+
+Then use `/analyze-experiment <new-experiment>` to verify no regressions. A successful optimization holds or improves all scenario means relative to the baseline.

--- a/backend/evaluate/langsmith_dataset.py
+++ b/backend/evaluate/langsmith_dataset.py
@@ -906,7 +906,9 @@ def _target_segments(target: str) -> list[str]:
     than _MIN_SEGMENT_LEN chars are dropped to avoid false matches on punctuation
     fragments.  Returned segments preserve case; match case-insensitively.
     """
-    return [s.strip() for s in target.split("...") if len(s.strip()) >= _MIN_SEGMENT_LEN]
+    return [
+        s.strip() for s in target.split("...") if len(s.strip()) >= _MIN_SEGMENT_LEN
+    ]
 
 
 def _target_in_text(target: str, text: str) -> bool:

--- a/backend/evaluate/langsmith_dataset.py
+++ b/backend/evaluate/langsmith_dataset.py
@@ -36,7 +36,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, NamedTuple
 
 import jsonschema
 from langchain_core.prompts import (
@@ -921,6 +921,15 @@ def _target_in_text(target: str, text: str) -> bool:
     return bool(segments) and all(seg.lower() in lowered for seg in segments)
 
 
+def _any_target_hit(targets: list[str], chunks: list[str]) -> bool:
+    """True if any STOPGAP target appears in any chunk.
+
+    Chunks should already be whitespace-normalized. Shared by the trace check
+    and the live re-query so the two probes match retrieved text identically.
+    """
+    return any(_target_in_text(t, c) for c in chunks for t in targets)
+
+
 def _check_stopgaps_against_corpus(
     stopgaps: list[dict[str, Any]],
     corpus_dir: Path,
@@ -974,39 +983,50 @@ def _check_stopgaps_against_corpus(
         )
 
 
-def _collect_tool_queries(client: Any, experiment: str) -> list[str]:
-    """Return all unique RAG query strings issued as tool calls in an experiment."""
-    p = _read_project(client, experiment)
-    queries: set[str] = set()
-    for run in client.list_runs(project_id=p.id, run_type="tool"):
-        q = (run.inputs or {}).get("query")
-        if q:
-            queries.add(q)
-    return sorted(queries)
+class _ExperimentTraces(NamedTuple):
+    """Everything the STOPGAP check needs from one experiment's runs.
+
+    queries          — unique RAG query strings issued as tool calls.
+    runs_by_id       — root run ID → ``{"example_id": str, "responses": [str, ...]}``.
+    latest_run_time  — latest root-run start time, or None.
+    """
+
+    queries: list[str]
+    runs_by_id: dict[str, dict[str, Any]]
+    latest_run_time: datetime | None
 
 
-def _collect_tool_responses_by_run(
-    client: Any, experiment: str
-) -> dict[str, dict[str, Any]]:
-    """Return RAG tool response texts grouped by repetition (root run).
+def _collect_experiment_traces(client: Any, experiment: str) -> _ExperimentTraces:
+    """Collect an experiment's tool queries, RAG responses, and latest run time.
+
+    Consolidates what were three separate scans of the same experiment — each
+    re-reading the project and re-paginating the run set — into one project read,
+    one root-run pass, and one tool-run pass.
 
     Each dataset example is run multiple times (``--num-repetitions``); every
     repetition is a distinct root run sharing the example's
     ``reference_example_id``. Grouping by root run keeps each repetition as an
     independent retrieval sample, while ``example_id`` carries the scenario link
     used for per-STOPGAP filtering downstream.
-
-    Returns a mapping of root run ID to
-    ``{"example_id": str, "responses": [str, ...]}``.
     """
     p = _read_project(client, experiment)
-    run_to_example: dict[str, str] = {
-        str(run.id): str(run.reference_example_id)
-        for run in client.list_runs(project_id=p.id, execution_order=1)
-        if run.reference_example_id
-    }
-    runs: dict[str, dict[str, Any]] = {}
+
+    run_to_example: dict[str, str] = {}
+    latest_run_time: datetime | None = None
+    for run in client.list_runs(project_id=p.id, execution_order=1):
+        if run.reference_example_id:
+            run_to_example[str(run.id)] = str(run.reference_example_id)
+        if run.start_time and (
+            latest_run_time is None or run.start_time > latest_run_time
+        ):
+            latest_run_time = run.start_time
+
+    queries: set[str] = set()
+    runs_by_id: dict[str, dict[str, Any]] = {}
     for run in client.list_runs(project_id=p.id, run_type="tool"):
+        q = (run.inputs or {}).get("query")
+        if q:
+            queries.add(q)
         root_id = str(run.trace_id)
         example_id = run_to_example.get(root_id)
         if not example_id:
@@ -1014,11 +1034,12 @@ def _collect_tool_responses_by_run(
         outputs = run.outputs or {}
         text = outputs.get("output") or outputs.get("content") or ""
         if isinstance(text, str) and text:
-            entry = runs.setdefault(
+            entry = runs_by_id.setdefault(
                 root_id, {"example_id": example_id, "responses": []}
             )
             entry["responses"].append(text)
-    return runs
+
+    return _ExperimentTraces(sorted(queries), runs_by_id, latest_run_time)
 
 
 def _check_retrieval_from_traces(
@@ -1072,7 +1093,7 @@ def _check_retrieval_from_traces(
         hits = 0
         for r in relevant_runs:
             norm = [re.sub(r"\s+", " ", resp) for resp in r["responses"]]
-            if any(_target_in_text(t, n) for n in norm for t in sg["targets"]):
+            if _any_target_hit(sg["targets"], norm):
                 hits += 1
         total_relevant = len(relevant_runs)
 
@@ -1092,17 +1113,6 @@ def _check_retrieval_from_traces(
         )
 
     return coverage_gap
-
-
-def _experiment_latest_run_time(client: Any, experiment: str) -> datetime | None:
-    """Return the latest root-run start time for an experiment, or None."""
-    p = _read_project(client, experiment)
-    times = [
-        run.start_time
-        for run in client.list_runs(project_id=p.id, execution_order=1)
-        if run.start_time
-    ]
-    return max(times) if times else None
 
 
 def _datastore_last_update_time() -> datetime | None:
@@ -1156,15 +1166,15 @@ def _as_utc(dt: datetime) -> datetime:
 
 
 def _datastore_unchanged_since_experiment(
-    client: Any, experiment: str, log: logging.Logger
+    exp_time: datetime | None, log: logging.Logger
 ) -> bool:
     """Return True if the laws datastore has not been reindexed since the experiment ran.
 
     Compares the datastore's last data-update time against the experiment's latest
-    root-run start time. Returns False when either timestamp is unavailable, so the
-    caller falls open and runs the live re-query rather than skipping it on a guess.
+    root-run start time (passed in by the caller). Returns False when either
+    timestamp is unavailable, so the caller falls open and runs the live re-query
+    rather than skipping it on a guess.
     """
-    exp_time = _experiment_latest_run_time(client, experiment)
     ds_time = _datastore_last_update_time()
     if exp_time is None or ds_time is None:
         log.info(
@@ -1497,11 +1507,12 @@ def cmd_runs_stopgap_check(args: argparse.Namespace) -> None:
 
     if args.experiment:
         client = make_client()
-        queries = _collect_tool_queries(client, args.experiment)
+        traces = _collect_experiment_traces(client, args.experiment)
+        queries = traces.queries
+        runs_by_id = traces.runs_by_id
         log.info(
             "Collected %d unique tool queries from %s", len(queries), args.experiment
         )
-        runs_by_id = _collect_tool_responses_by_run(client, args.experiment)
         coverage_gap = False
         if runs_by_id:
             example_ids = {r["example_id"] for r in runs_by_id.values()}
@@ -1519,7 +1530,7 @@ def cmd_runs_stopgap_check(args: argparse.Namespace) -> None:
         if (
             not args.force_requery
             and not coverage_gap
-            and _datastore_unchanged_since_experiment(client, args.experiment, log)
+            and _datastore_unchanged_since_experiment(traces.latest_run_time, log)
         ):
             log.info(
                 "Datastore unchanged since %s ran and the trace check covered every "
@@ -1545,28 +1556,33 @@ def cmd_runs_stopgap_check(args: argparse.Namespace) -> None:
 
     print(f"\nRetrieval params: {max_results} docs x {max_segments} segments\n")
 
+    # Query Vertex once per unique query and cache the normalized segment texts.
+    # The retrieved segments depend only on the query (and the fixed params), not
+    # on the STOPGAP, so probing each STOPGAP separately would re-issue identical
+    # paid searches — N STOPGAPs would multiply the call count N-fold.
+    segments_by_query: dict[str, list[str]] = {}
+    for q in queries:
+        res = vertex_search(
+            q,
+            state=state,
+            max_results=max_results,
+            max_extractive_answer_count=1,
+            max_extractive_segment_count=max_segments,
+        )
+        segments_by_query[q] = [
+            re.sub(r"\s+", " ", seg.get("content") or "")
+            for result in res.results
+            for seg in (result.document.derived_struct_data or {}).get(
+                "extractive_segments", []
+            )
+        ]
+
     for sg in stopgaps:
         hits = 0
         rows: list[tuple[str, str]] = []
 
         for q in queries:
-            res = vertex_search(
-                q,
-                state=state,
-                max_results=max_results,
-                max_extractive_answer_count=1,
-                max_extractive_segment_count=max_segments,
-            )
-            hit = False
-            for result in res.results:
-                struct = result.document.derived_struct_data or {}
-                for seg in struct.get("extractive_segments", []):
-                    content = re.sub(r"\s+", " ", seg.get("content") or "")
-                    if any(_target_in_text(t, content) for t in sg["targets"]):
-                        hit = True
-                        break
-                if hit:
-                    break
+            hit = _any_target_hit(sg["targets"], segments_by_query[q])
             hits += hit
             rows.append(("HIT " if hit else "miss", q[:72]))
 

--- a/backend/evaluate/langsmith_dataset.py
+++ b/backend/evaluate/langsmith_dataset.py
@@ -26,6 +26,7 @@ Usage examples:
 import argparse
 import difflib
 import json
+import logging
 import math
 import re
 import statistics
@@ -61,6 +62,7 @@ EVALUATE_DIR = Path(__file__).parent
 DEFAULT_SCHEMA = EVALUATE_DIR / "langsmith_example_schema.json"
 DEFAULT_DATASET_NAME = "tenant-legal-qa-scenarios"
 DEFAULT_JSONL = EVALUATE_DIR / "dataset-tenant-legal-qa-examples.jsonl"
+_SYSTEM_PROMPT_PATH = EVALUATE_DIR.parent / "tenantfirstaid" / "system_prompt.md"
 
 # LangSmith's default trace retention; queries reaching further back return
 # nothing older than this because expired traces are already purged.
@@ -866,6 +868,290 @@ def cmd_experiment_stats(args: argparse.Namespace) -> None:
 # ── run subcommands ────────────────────────────────────────────────────────────
 
 
+def _parse_stopgaps(prompt_path: Path) -> list[dict[str, Any]]:
+    """Parse STOPGAP entries from a system prompt markdown file.
+
+    Returns a list of dicts with:
+      label   — human-readable label (markdown links stripped)
+      targets — verbatim quoted phrases to substring-match in retrieved text
+    """
+    lines = prompt_path.read_text().splitlines()
+    stopgaps: list[dict[str, Any]] = []
+    i = 0
+    while i < len(lines):
+        m = re.match(r"^- \*\*STOPGAP — (.+?)\.\*\*(.*)", lines[i])
+        if m:
+            label = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", m.group(1))
+            targets: list[str] = re.findall(r'"([^"]+)"', m.group(2))
+            j = i + 1
+            while j < len(lines) and lines[j].startswith("  "):
+                targets.extend(re.findall(r'"([^"]+)"', lines[j]))
+                j += 1
+            stopgaps.append({"label": label, "targets": targets})
+            i = j
+        else:
+            i += 1
+    return stopgaps
+
+
+_CORPUS_DIR = EVALUATE_DIR.parent / "scripts" / "documents"
+_MIN_SEGMENT_LEN = 10  # ignore fragments shorter than this when checking elided quotes
+
+
+def _check_stopgaps_against_corpus(
+    stopgaps: list[dict[str, Any]],
+    corpus_dir: Path,
+    log: logging.Logger,
+) -> None:
+    """Warn if any STOPGAP target phrase (or segment) is absent from the local corpus.
+
+    Targets may contain '...' to elide text; each non-empty segment around the
+    ellipsis is checked independently, since the surrounding clauses may not be
+    adjacent in the source file.  Segments shorter than _MIN_SEGMENT_LEN chars
+    are skipped to avoid false positives from punctuation fragments.
+
+    This is a sanity check, not a hard failure — a mismatch means the STOPGAP
+    may have been transcribed incorrectly or the corpus has since been updated.
+    """
+    corpus_files = sorted(corpus_dir.rglob("*.txt"))
+    if not corpus_files:
+        log.warning("No corpus .txt files found under %s — skipping corpus check", corpus_dir)
+        return
+
+    # Collapse all whitespace runs to a single space so multi-line statutory text
+    # matches single-line STOPGAP quotes that span paragraph line-breaks.
+    raw = "\n".join(f.read_text() for f in corpus_files)
+    corpus_text = re.sub(r"\s+", " ", raw).lower()
+    log.info("Corpus check: loaded %d file(s) from %s", len(corpus_files), corpus_dir)
+
+    any_miss = False
+    for sg in stopgaps:
+        for target in sg["targets"]:
+            segments = [s.strip() for s in target.split("...")]
+            for seg in segments:
+                if len(seg) < _MIN_SEGMENT_LEN:
+                    continue
+                if seg.lower() not in corpus_text:
+                    log.warning(
+                        "STOPGAP corpus mismatch — segment not found verbatim in local "
+                        "corpus.\n"
+                        "  The retrieval probe will also report a false miss for this "
+                        "target.\n"
+                        "  Fix: update the STOPGAP quote to match the corpus exactly, or "
+                        "shorten the target to a verbatim phrase.\n"
+                        "  STOPGAP : %s\n"
+                        "  segment : %r",
+                        sg["label"],
+                        seg[:120],
+                    )
+                    any_miss = True
+
+    if not any_miss:
+        log.info("Corpus check passed — all STOPGAP target segments found verbatim in corpus")
+
+
+def _collect_tool_queries(client: Any, experiment: str) -> list[str]:
+    """Return all unique RAG query strings issued as tool calls in an experiment."""
+    p = _read_project(client, experiment)
+    queries: set[str] = set()
+    for run in client.list_runs(project_id=p.id, run_type="tool"):
+        q = (run.inputs or {}).get("query")
+        if q:
+            queries.add(q)
+    return sorted(queries)
+
+
+def _collect_tool_responses_by_run(
+    client: Any, experiment: str
+) -> dict[str, dict[str, Any]]:
+    """Return RAG tool response texts grouped by repetition (root run).
+
+    Each dataset example is run multiple times (``--num-repetitions``); every
+    repetition is a distinct root run sharing the example's
+    ``reference_example_id``. Grouping by root run keeps each repetition as an
+    independent retrieval sample, while ``example_id`` carries the scenario link
+    used for per-STOPGAP filtering downstream.
+
+    Returns a mapping of root run ID to
+    ``{"example_id": str, "responses": [str, ...]}``.
+    """
+    p = _read_project(client, experiment)
+    run_to_example: dict[str, str] = {
+        str(run.id): str(run.reference_example_id)
+        for run in client.list_runs(project_id=p.id, execution_order=1)
+        if run.reference_example_id
+    }
+    runs: dict[str, dict[str, Any]] = {}
+    for run in client.list_runs(project_id=p.id, run_type="tool"):
+        root_id = str(run.trace_id)
+        example_id = run_to_example.get(root_id)
+        if not example_id:
+            continue
+        outputs = run.outputs or {}
+        text = outputs.get("output") or outputs.get("content") or ""
+        if isinstance(text, str) and text:
+            entry = runs.setdefault(
+                root_id, {"example_id": example_id, "responses": []}
+            )
+            entry["responses"].append(text)
+    return runs
+
+
+def _check_retrieval_from_traces(
+    stopgaps: list[dict[str, Any]],
+    runs_by_id: dict[str, dict[str, Any]],
+    facts_by_example: dict[str, list[str]],
+    log: logging.Logger,
+) -> bool:
+    """Log per-STOPGAP retrieval hit rates over repetitions, filtered to scenarios
+    covering each statute.
+
+    The sampling unit is the repetition (root run): a repetition counts as a hit
+    if any of its tool responses contains the STOPGAP's verbatim target text. For
+    each STOPGAP, the ORS number is extracted from its label and the denominator
+    is restricted to repetitions of examples whose facts mention that statute.
+    This is the L1/L2 layer check: did the right text land in retrieved passages
+    during this experiment, for the runs that were supposed to retrieve it?
+
+    Returns True if any STOPGAP had no relevant repetitions in the trace (a
+    coverage gap), since the live re-query can still probe such a STOPGAP even
+    when the datastore is unchanged.
+    """
+    n_examples = len({r["example_id"] for r in runs_by_id.values()})
+    log.info(
+        "L1/L2 trace check — %d repetition(s) across %d example(s):",
+        len(runs_by_id),
+        n_examples,
+    )
+    coverage_gap = False
+    for sg in stopgaps:
+        ors_match = re.search(r"\b(\d+\.\d+)", sg["label"])
+        ors_num = ors_match.group(1) if ors_match else None
+
+        if ors_num:
+            relevant_eids = {
+                eid
+                for eid, facts in facts_by_example.items()
+                if any(ors_num in fact for fact in facts)
+            }
+        else:
+            relevant_eids = {r["example_id"] for r in runs_by_id.values()}
+
+        relevant_runs = [
+            r for r in runs_by_id.values() if r["example_id"] in relevant_eids
+        ]
+        if not relevant_runs:
+            log.info("  [%s] no relevant scenarios found in experiment", sg["label"])
+            coverage_gap = True
+            continue
+
+        targets_lower = [t.lower() for t in sg["targets"]]
+        hits = 0
+        for r in relevant_runs:
+            norm = [re.sub(r"\s+", " ", resp).lower() for resp in r["responses"]]
+            if any(t in n for n in norm for t in targets_lower):
+                hits += 1
+        total_relevant = len(relevant_runs)
+
+        if hits == total_relevant:
+            status = "retirement candidate"
+        elif hits == 0:
+            status = "never retrieved"
+        else:
+            status = "partially retrieved"
+
+        log.info(
+            "  [%s] retrieved in %d/%d relevant repetition(s) — %s",
+            sg["label"],
+            hits,
+            total_relevant,
+            status,
+        )
+
+    return coverage_gap
+
+
+def _experiment_latest_run_time(client: Any, experiment: str) -> datetime | None:
+    """Return the latest root-run start time for an experiment, or None."""
+    p = _read_project(client, experiment)
+    times = [
+        run.start_time
+        for run in client.list_runs(project_id=p.id, execution_order=1)
+        if run.start_time
+    ]
+    return max(times) if times else None
+
+
+def _datastore_last_update_time() -> datetime | None:
+    """Return the laws datastore's last data-update time, or None if unavailable.
+
+    Reads ``DataStore.billing_estimation`` from the Discovery Engine API, which
+    records when the structured/unstructured data was last updated (i.e. the last
+    reindex). Returns None on any failure so callers fall open.
+    """
+    try:
+        from google.cloud import discoveryengine_v1beta as discoveryengine
+
+        from tenantfirstaid.constants import SINGLETON, DatastoreKey
+        from tenantfirstaid.google_auth import (
+            discoveryengine_client_options,
+            load_gcp_credentials,
+        )
+
+        credentials = load_gcp_credentials(SINGLETON.GOOGLE_APPLICATION_CREDENTIALS)
+        location = SINGLETON.GOOGLE_CLOUD_LOCATION
+        client = discoveryengine.DataStoreServiceClient(
+            credentials=credentials,
+            client_options=discoveryengine_client_options(location),
+        )
+        datastore = SINGLETON.VERTEX_AI_DATASTORES[DatastoreKey.LAWS]
+        name = (
+            f"projects/{SINGLETON.GOOGLE_CLOUD_PROJECT}"
+            f"/locations/{location}"
+            f"/collections/default_collection"
+            f"/dataStores/{datastore}"
+        )
+        est = client.get_data_store(name=name).billing_estimation
+        times = [
+            t
+            for t in (
+                est.unstructured_data_update_time,
+                est.structured_data_update_time,
+            )
+            if t
+        ]
+        return max(times) if times else None
+    except Exception:
+        return None
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Normalize a datetime to timezone-aware UTC for safe comparison."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _datastore_unchanged_since_experiment(
+    client: Any, experiment: str, log: logging.Logger
+) -> bool:
+    """Return True if the laws datastore has not been reindexed since the experiment ran.
+
+    Compares the datastore's last data-update time against the experiment's latest
+    root-run start time. Returns False when either timestamp is unavailable, so the
+    caller falls open and runs the live re-query rather than skipping it on a guess.
+    """
+    exp_time = _experiment_latest_run_time(client, experiment)
+    ds_time = _datastore_last_update_time()
+    if exp_time is None or ds_time is None:
+        log.info(
+            "Could not determine datastore vs. experiment timing; running the live "
+            "re-query to be safe."
+        )
+        return False
+    return _as_utc(ds_time) <= _as_utc(exp_time)
+
+
 def cmd_run_list(args: argparse.Namespace) -> None:
     client = make_client()
     p = _read_project(client, args.experiment)
@@ -1150,6 +1436,122 @@ def cmd_prompt_pull(args: argparse.Namespace) -> None:
 
     local.write_text(rubric_text)
     print(f"Pulled '{args.name}' → {local}")
+
+
+def cmd_runs_stopgap_check(args: argparse.Namespace) -> None:
+    """Check whether each system-prompt STOPGAP's verbatim text is retrievable.
+
+    Two use cases:
+      Retirement signal  — pass an experiment name; queries are pulled from its
+                           tool runs (the real queries the agent issued).
+      Regression check   — omit experiment, pass --query flags; useful after a
+                           corpus reindex or datastore update.
+
+    A STOPGAP is a retirement candidate when its hit rate reaches N/N at
+    production params. Confirm by running a comparative eval without it.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s  %(message)s")
+    log = logging.getLogger(__name__)
+
+    from scripts.vertex_ai_search import search as vertex_search  # deferred: needs env
+    from tenantfirstaid.location import UsaState
+
+    prompt_path: Path = args.prompt
+    stopgaps = _parse_stopgaps(prompt_path)
+
+    if not stopgaps:
+        print(f"No STOPGAPs found in {prompt_path}.", file=sys.stderr)
+        sys.exit(1)
+
+    log.info("Found %d STOPGAP(s) in %s", len(stopgaps), prompt_path.name)
+    for sg in stopgaps:
+        log.info("  %s  [%d target phrase(s)]", sg["label"], len(sg["targets"]))
+        for t in sg["targets"]:
+            snippet = t[:80] + ("..." if len(t) > 80 else "")
+            log.info("    %r", snippet)
+
+    _check_stopgaps_against_corpus(stopgaps, _CORPUS_DIR, log)
+
+    if args.experiment:
+        client = make_client()
+        queries = _collect_tool_queries(client, args.experiment)
+        log.info(
+            "Collected %d unique tool queries from %s", len(queries), args.experiment
+        )
+        runs_by_id = _collect_tool_responses_by_run(client, args.experiment)
+        coverage_gap = False
+        if runs_by_id:
+            example_ids = {r["example_id"] for r in runs_by_id.values()}
+            facts_by_example: dict[str, list[str]] = {
+                str(ex.id): list((ex.outputs or {}).get("facts") or [])
+                for ex in client.list_examples(example_ids=list(example_ids))
+            }
+            coverage_gap = _check_retrieval_from_traces(
+                stopgaps, runs_by_id, facts_by_example, log
+            )
+        # The live re-query only adds information when the datastore has changed
+        # since the experiment (e.g. a reindex), or when the trace check left a
+        # coverage gap it can probe directly. Otherwise it would just reproduce
+        # the trace at the cost of live Vertex AI calls, so short-circuit.
+        if (
+            not args.force_requery
+            and not coverage_gap
+            and _datastore_unchanged_since_experiment(client, args.experiment, log)
+        ):
+            log.info(
+                "Datastore unchanged since %s ran and the trace check covered every "
+                "STOPGAP; skipping the live Vertex AI re-query (it would reproduce the "
+                "trace). Reindex, omit the experiment and pass --query, or pass "
+                "--force-requery to run it anyway.",
+                args.experiment,
+            )
+            return
+    else:
+        queries = list(args.query or [])
+
+    if not queries:
+        print(
+            "No queries to probe. Pass an experiment name or one or more --query flags.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    max_results: int = args.max_results
+    max_segments: int = args.max_segments
+    state = UsaState("or")
+
+    print(f"\nRetrieval params: {max_results} docs x {max_segments} segments\n")
+
+    for sg in stopgaps:
+        targets_lower = [t.lower() for t in sg["targets"]]
+        hits = 0
+        rows: list[tuple[str, str]] = []
+
+        for q in queries:
+            res = vertex_search(
+                q,
+                state=state,
+                max_results=max_results,
+                max_extractive_answer_count=1,
+                max_extractive_segment_count=max_segments,
+            )
+            hit = False
+            for result in res.results:
+                struct = result.document.derived_struct_data or {}
+                for seg in struct.get("extractive_segments", []):
+                    content = (seg.get("content") or "").lower()
+                    if any(t in content for t in targets_lower):
+                        hit = True
+                        break
+                if hit:
+                    break
+            hits += hit
+            rows.append(("HIT " if hit else "miss", q[:72]))
+
+        print(f"=== {sg['label']} ===")
+        for status, q in rows:
+            print(f"  [{status}] {q}")
+        print(f"  -> STOPGAP text retrieved on {hits}/{len(queries)} queries\n")
 
 
 # ── argument parser ────────────────────────────────────────────────────────────
@@ -1621,6 +2023,71 @@ def build_parser() -> argparse.ArgumentParser:
         help="Include tool call arguments, tool responses, and LLM output at each node.",
     )
     p.set_defaults(func=cmd_run_trace)
+
+    p = runs_sub.add_parser(
+        "stopgap-check",
+        help=(
+            "Check whether each system-prompt STOPGAP's verbatim text is retrievable "
+            "at production params."
+        ),
+        description=(
+            "Parses STOPGAP entries from system_prompt.md, logs each one found at INFO "
+            "level, then probes Vertex AI Search to report hit rate per STOPGAP.\n\n"
+            "Two use cases:\n"
+            "  Retirement signal  — pass an experiment name; queries come from its tool "
+            "runs.\n"
+            "                       A STOPGAP whose hit rate reaches N/N is a retirement "
+            "candidate.\n"
+            "  Regression check   — omit experiment, pass --query flags; verify specific "
+            "queries\n"
+            "                       still hit after a corpus reindex or datastore update."
+        ),
+    )
+    p.add_argument(
+        "experiment",
+        nargs="?",
+        metavar="name-or-uuid",
+        help=(
+            "LangSmith experiment to pull production queries from. "
+            "Omit to use --query instead."
+        ),
+    )
+    p.add_argument(
+        "--query",
+        action="append",
+        metavar="text",
+        help="Ad-hoc query to probe (repeatable). Used when no experiment is given.",
+    )
+    p.add_argument(
+        "--prompt",
+        type=Path,
+        default=_SYSTEM_PROMPT_PATH,
+        metavar="path",
+        help="Path to system_prompt.md (default: %(default)s).",
+    )
+    p.add_argument(
+        "--max-results",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Documents per query (default: %(default)s — matches production).",
+    )
+    p.add_argument(
+        "--max-segments",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Extractive segments per document (default: %(default)s — matches production).",
+    )
+    p.add_argument(
+        "--force-requery",
+        action="store_true",
+        help=(
+            "Run the live Vertex AI re-query even when the datastore is unchanged "
+            "since the experiment ran (by default it is skipped as redundant)."
+        ),
+    )
+    p.set_defaults(func=cmd_runs_stopgap_check)
 
     # ── prompt ───────────────────────────────────────────────────────────────
     pr_parser = nouns.add_parser(

--- a/backend/evaluate/langsmith_dataset.py
+++ b/backend/evaluate/langsmith_dataset.py
@@ -898,6 +898,29 @@ _CORPUS_DIR = EVALUATE_DIR.parent / "scripts" / "documents"
 _MIN_SEGMENT_LEN = 10  # ignore fragments shorter than this when checking elided quotes
 
 
+def _target_segments(target: str) -> list[str]:
+    """Split a STOPGAP target on '...' into the verbatim segments worth matching.
+
+    Targets may use '...' to elide text; the clauses around the ellipsis may not
+    be adjacent in the source, so each is matched independently.  Segments shorter
+    than _MIN_SEGMENT_LEN chars are dropped to avoid false matches on punctuation
+    fragments.  Returned segments preserve case; match case-insensitively.
+    """
+    return [s.strip() for s in target.split("...") if len(s.strip()) >= _MIN_SEGMENT_LEN]
+
+
+def _target_in_text(target: str, text: str) -> bool:
+    """True if every verbatim segment of a STOPGAP target appears in text.
+
+    Matching is case-insensitive; callers should whitespace-normalize text so
+    that quotes spanning line-breaks still match.  A target with no segment that
+    clears _MIN_SEGMENT_LEN never matches.
+    """
+    segments = _target_segments(target)
+    lowered = text.lower()
+    return bool(segments) and all(seg.lower() in lowered for seg in segments)
+
+
 def _check_stopgaps_against_corpus(
     stopgaps: list[dict[str, Any]],
     corpus_dir: Path,
@@ -915,7 +938,9 @@ def _check_stopgaps_against_corpus(
     """
     corpus_files = sorted(corpus_dir.rglob("*.txt"))
     if not corpus_files:
-        log.warning("No corpus .txt files found under %s — skipping corpus check", corpus_dir)
+        log.warning(
+            "No corpus .txt files found under %s — skipping corpus check", corpus_dir
+        )
         return
 
     # Collapse all whitespace runs to a single space so multi-line statutory text
@@ -927,10 +952,7 @@ def _check_stopgaps_against_corpus(
     any_miss = False
     for sg in stopgaps:
         for target in sg["targets"]:
-            segments = [s.strip() for s in target.split("...")]
-            for seg in segments:
-                if len(seg) < _MIN_SEGMENT_LEN:
-                    continue
+            for seg in _target_segments(target):
                 if seg.lower() not in corpus_text:
                     log.warning(
                         "STOPGAP corpus mismatch — segment not found verbatim in local "
@@ -947,7 +969,9 @@ def _check_stopgaps_against_corpus(
                     any_miss = True
 
     if not any_miss:
-        log.info("Corpus check passed — all STOPGAP target segments found verbatim in corpus")
+        log.info(
+            "Corpus check passed — all STOPGAP target segments found verbatim in corpus"
+        )
 
 
 def _collect_tool_queries(client: Any, experiment: str) -> list[str]:
@@ -1045,11 +1069,10 @@ def _check_retrieval_from_traces(
             coverage_gap = True
             continue
 
-        targets_lower = [t.lower() for t in sg["targets"]]
         hits = 0
         for r in relevant_runs:
-            norm = [re.sub(r"\s+", " ", resp).lower() for resp in r["responses"]]
-            if any(t in n for n in norm for t in targets_lower):
+            norm = [re.sub(r"\s+", " ", resp) for resp in r["responses"]]
+            if any(_target_in_text(t, n) for n in norm for t in sg["targets"]):
                 hits += 1
         total_relevant = len(relevant_runs)
 
@@ -1523,7 +1546,6 @@ def cmd_runs_stopgap_check(args: argparse.Namespace) -> None:
     print(f"\nRetrieval params: {max_results} docs x {max_segments} segments\n")
 
     for sg in stopgaps:
-        targets_lower = [t.lower() for t in sg["targets"]]
         hits = 0
         rows: list[tuple[str, str]] = []
 
@@ -1539,8 +1561,8 @@ def cmd_runs_stopgap_check(args: argparse.Namespace) -> None:
             for result in res.results:
                 struct = result.document.derived_struct_data or {}
                 for seg in struct.get("extractive_segments", []):
-                    content = (seg.get("content") or "").lower()
-                    if any(t in content for t in targets_lower):
+                    content = re.sub(r"\s+", " ", seg.get("content") or "")
+                    if any(_target_in_text(t, content) for t in sg["targets"]):
                         hit = True
                         break
                 if hit:

--- a/backend/evaluate/langsmith_evaluators.py
+++ b/backend/evaluate/langsmith_evaluators.py
@@ -104,37 +104,32 @@ def load_rubric(name: str) -> str:
 # get the evaluator; @cache makes each one a singleton.
 
 
+def _make_judge(rubric: str, feedback_key: str) -> SimpleEvaluator:
+    """Build an LLM-as-judge evaluator from a rubric file and feedback key."""
+    return create_llm_as_judge(
+        judge=_evaluator_judge(),
+        prompt=load_rubric(rubric),
+        feedback_key=feedback_key,
+        continuous=True,
+    )
+
+
 # Evaluator: Citation Accuracy (LLM-as-Judge).
 @cache
 def citation_accuracy_evaluator() -> SimpleEvaluator:
-    return create_llm_as_judge(
-        judge=_evaluator_judge(),
-        prompt=load_rubric("citation_accuracy"),
-        feedback_key="citation accuracy",
-        continuous=True,
-    )
+    return _make_judge("citation_accuracy", "citation accuracy")
 
 
 # Evaluator: Legal Correctness (LLM-as-Judge).
 @cache
 def legal_correctness_evaluator() -> SimpleEvaluator:
-    return create_llm_as_judge(
-        judge=_evaluator_judge(),
-        prompt=load_rubric("legal_correctness"),
-        feedback_key="legal correctness",
-        continuous=True,
-    )
+    return _make_judge("legal_correctness", "legal correctness")
 
 
 # Evaluator: Tone & Professionalism (LLM-as-Judge).
 @cache
 def tone_evaluator() -> SimpleEvaluator:
-    return create_llm_as_judge(
-        judge=_evaluator_judge(),
-        prompt=load_rubric("tone"),
-        feedback_key="appropriate tone",
-        continuous=True,
-    )
+    return _make_judge("tone", "appropriate tone")
 
 
 # Evaluator: Citation Format (Heuristic).

--- a/backend/evaluate/langsmith_evaluators.py
+++ b/backend/evaluate/langsmith_evaluators.py
@@ -21,6 +21,7 @@ from openevals.types import SimpleEvaluator
 # NOTE: can (should?) use different models for chatbot LLM & evaluator
 EVALUATOR_MODEL_NAME: Final = "gemini-3-flash-preview"
 
+
 # Use vertexai=True so the evaluator uses service account credentials rather
 # than a Gemini API key. init_chat_model routes gemini-3-flash-preview to
 # us-central1 by default, which returns 404 — constructing the judge directly
@@ -37,6 +38,7 @@ def _evaluator_judge() -> ChatGoogleGenerativeAI:
     return ChatGoogleGenerativeAI(
         model=EVALUATOR_MODEL_NAME, vertexai=True, location="global"
     )
+
 
 EVALUATORS_DIR: Final = Path(__file__).parent / "evaluators"
 

--- a/backend/evaluate/langsmith_evaluators.py
+++ b/backend/evaluate/langsmith_evaluators.py
@@ -9,6 +9,7 @@ without touching Python code.
 """
 
 import re
+from functools import cache
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, Final
@@ -24,9 +25,18 @@ EVALUATOR_MODEL_NAME: Final = "gemini-3-flash-preview"
 # than a Gemini API key. init_chat_model routes gemini-3-flash-preview to
 # us-central1 by default, which returns 404 — constructing the judge directly
 # avoids that routing issue.
-_EVALUATOR_JUDGE: Final = ChatGoogleGenerativeAI(
-    model=EVALUATOR_MODEL_NAME, vertexai=True, location="global"
-)
+@cache
+def _evaluator_judge() -> ChatGoogleGenerativeAI:
+    """Construct the LLM-as-judge lazily (cached singleton).
+
+    Building ChatGoogleGenerativeAI opens an httpx client, so doing it at module
+    scope gives every importer of this module a network side effect — which also
+    breaks test collection under proxies that need extra httpx extras. Deferring
+    construction to first use keeps importing this module side-effect-free.
+    """
+    return ChatGoogleGenerativeAI(
+        model=EVALUATOR_MODEL_NAME, vertexai=True, location="global"
+    )
 
 EVALUATORS_DIR: Final = Path(__file__).parent / "evaluators"
 
@@ -88,29 +98,43 @@ def load_rubric(name: str) -> str:
 # but Gemini's protobuf layer requires enum values to be strings, not floats,
 # and raises a ParseError at runtime.
 
+# These LLM-as-judge evaluators are exposed as cached factory functions rather
+# than module-level objects so that importing this module never constructs the
+# judge (and thus never opens a network client). Callers invoke the factory to
+# get the evaluator; @cache makes each one a singleton.
+
+
 # Evaluator: Citation Accuracy (LLM-as-Judge).
-citation_accuracy_evaluator: SimpleEvaluator = create_llm_as_judge(
-    judge=_EVALUATOR_JUDGE,
-    prompt=load_rubric("citation_accuracy"),
-    feedback_key="citation accuracy",
-    continuous=True,
-)
+@cache
+def citation_accuracy_evaluator() -> SimpleEvaluator:
+    return create_llm_as_judge(
+        judge=_evaluator_judge(),
+        prompt=load_rubric("citation_accuracy"),
+        feedback_key="citation accuracy",
+        continuous=True,
+    )
+
 
 # Evaluator: Legal Correctness (LLM-as-Judge).
-legal_correctness_evaluator: SimpleEvaluator = create_llm_as_judge(
-    judge=_EVALUATOR_JUDGE,
-    prompt=load_rubric("legal_correctness"),
-    feedback_key="legal correctness",
-    continuous=True,
-)
+@cache
+def legal_correctness_evaluator() -> SimpleEvaluator:
+    return create_llm_as_judge(
+        judge=_evaluator_judge(),
+        prompt=load_rubric("legal_correctness"),
+        feedback_key="legal correctness",
+        continuous=True,
+    )
+
 
 # Evaluator: Tone & Professionalism (LLM-as-Judge).
-tone_evaluator: SimpleEvaluator = create_llm_as_judge(
-    judge=_EVALUATOR_JUDGE,
-    prompt=load_rubric("tone"),
-    feedback_key="appropriate tone",
-    continuous=True,
-)
+@cache
+def tone_evaluator() -> SimpleEvaluator:
+    return create_llm_as_judge(
+        judge=_evaluator_judge(),
+        prompt=load_rubric("tone"),
+        feedback_key="appropriate tone",
+        continuous=True,
+    )
 
 
 # Evaluator: Citation Format (Heuristic).

--- a/backend/evaluate/measure_evaluator_variance.py
+++ b/backend/evaluate/measure_evaluator_variance.py
@@ -40,7 +40,9 @@ from tenantfirstaid.constants import LANGSMITH_API_KEY
 # How many progress lines to emit during the thread-pool run.
 _PROGRESS_INTERVALS = 20
 
-# All available evaluators, keyed by their feedback_key.
+# All available evaluators, keyed by their feedback_key. The values are factory
+# functions (not evaluators); call one to construct its evaluator on demand. This
+# keeps importing this module free of the judge's network side effect.
 _ALL_EVALUATORS = {
     "legal correctness": legal_correctness_evaluator,
     "appropriate tone": tone_evaluator,
@@ -149,9 +151,9 @@ def measure_evaluator_variance(
             raise ValueError(
                 f"Unknown evaluator(s): {unknown}. Available: {list(_ALL_EVALUATORS)}"
             )
-        evaluators = {name: _ALL_EVALUATORS[name] for name in evaluator_names}
+        selected_names = list(evaluator_names)
     else:
-        evaluators = _ALL_EVALUATORS
+        selected_names = list(_ALL_EVALUATORS)
 
     client = Client(api_key=LANGSMITH_API_KEY)
 
@@ -186,6 +188,11 @@ def measure_evaluator_variance(
         if not runs_by_example:
             print(f"No runs found for scenario_id(s) {scenario_ids_filter}.")
             return
+
+    # Construct the evaluators only now that we know there is work to do — each
+    # factory builds an LLM judge with a live network client, so we avoid that
+    # cost (and its failure modes) on the no-runs and no-matching-scenario paths.
+    evaluators = {name: _ALL_EVALUATORS[name]() for name in selected_names}
 
     total_runs = sum(
         min(len(r), runs_per_scenario) if runs_per_scenario else len(r)

--- a/backend/evaluate/run_langsmith_evaluation.py
+++ b/backend/evaluate/run_langsmith_evaluation.py
@@ -150,10 +150,10 @@ def run_evaluation(
         #         Callable[..., Union[Dict[Any, Any], EvaluationResult, EvaluationResults]]
         Any
     ] = [
-        # citation_accuracy_evaluator,
-        legal_correctness_evaluator,
+        # citation_accuracy_evaluator(),
+        legal_correctness_evaluator(),
         # completeness_evaluator,
-        tone_evaluator,
+        tone_evaluator(),
         # citation_format_evaluator,
         # tool_usage_evaluator,
         # performance_evaluator,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,11 +1,14 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import evaluate.measure_evaluator_variance
-import evaluate.run_langsmith_evaluation
 import pytest
 from flask import Flask
 
+# Imported for side effects: the autouse fixture below patches attributes on
+# these submodules by string path, which requires them to be importable as
+# attributes of the `evaluate` package.
+import evaluate.measure_evaluator_variance  # noqa: F401
+import evaluate.run_langsmith_evaluation  # noqa: F401
 from tenantfirstaid.location import OregonCity, UsaState
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import evaluate.measure_evaluator_variance
+import evaluate.run_langsmith_evaluation
 import pytest
 from flask import Flask
 

--- a/backend/tests/test_langsmith_dataset.py
+++ b/backend/tests/test_langsmith_dataset.py
@@ -15,10 +15,9 @@ from evaluate.langsmith_dataset import (
     _apply_dataset_schemas,
     _as_utc,
     _check_retrieval_from_traces,
-    _collect_tool_responses_by_run,
+    _collect_experiment_traces,
     _datastore_unchanged_since_experiment,
     _example_content_diff,
-    _experiment_latest_run_time,
     _experiment_scores,
     _extract_rubric,
     _git_is_clean,
@@ -1731,19 +1730,21 @@ def test_cmd_run_trace_verbose_recurses_into_child_runs(capsys):
     assert "child input" in out
 
 
-# ── _collect_tool_responses_by_run ────────────────────────────────────────────
+# ── _collect_experiment_traces ────────────────────────────────────────────────
 
 
 def _make_root_run(run_id, example_id):
     run = MagicMock()
     run.id = run_id
     run.reference_example_id = example_id
+    run.start_time = None
     return run
 
 
-def _make_tool_run(trace_id, output_text):
+def _make_tool_run(trace_id, output_text, query="q"):
     run = MagicMock()
     run.trace_id = trace_id
+    run.inputs = {"query": query}
     run.outputs = {"output": output_text}
     return run
 
@@ -1758,7 +1759,7 @@ def test_collect_tool_responses_groups_by_run():
         [_make_root_run(root_id, example_id)],
         [_make_tool_run(root_id, "ORS 90.425 text here")],
     ]
-    result = _collect_tool_responses_by_run(client, "exp-name")
+    result = _collect_experiment_traces(client, "exp-name").runs_by_id
     assert str(root_id) in result
     assert result[str(root_id)]["example_id"] == str(example_id)
     assert result[str(root_id)]["responses"] == ["ORS 90.425 text here"]
@@ -1777,7 +1778,7 @@ def test_collect_tool_responses_multiple_calls_same_run():
             _make_tool_run(root_id, "second response"),
         ],
     ]
-    result = _collect_tool_responses_by_run(client, "exp-name")
+    result = _collect_experiment_traces(client, "exp-name").runs_by_id
     assert len(result[str(root_id)]["responses"]) == 2
 
 
@@ -1798,7 +1799,7 @@ def test_collect_tool_responses_separates_repetitions_of_same_example():
             _make_tool_run(root_id_b, "rep B response"),
         ],
     ]
-    result = _collect_tool_responses_by_run(client, "exp-name")
+    result = _collect_experiment_traces(client, "exp-name").runs_by_id
     assert len(result) == 2
     assert result[str(root_id_a)]["example_id"] == str(example_id)
     assert result[str(root_id_b)]["example_id"] == str(example_id)
@@ -1818,7 +1819,7 @@ def test_collect_tool_responses_skips_unmatched_trace_id():
             _make_tool_run(orphan_id, "unmatched response"),
         ],
     ]
-    result = _collect_tool_responses_by_run(client, "exp-name")
+    result = _collect_experiment_traces(client, "exp-name").runs_by_id
     assert len(result) == 1
     assert result[str(root_id)]["responses"] == ["matched response"]
 
@@ -1835,7 +1836,7 @@ def test_collect_tool_responses_skips_empty_output():
         [_make_root_run(root_id, example_id)],
         [empty_run],
     ]
-    result = _collect_tool_responses_by_run(client, "exp-name")
+    result = _collect_experiment_traces(client, "exp-name").runs_by_id
     assert result == {}
 
 
@@ -1851,8 +1852,28 @@ def test_collect_tool_responses_accepts_content_key():
         [_make_root_run(root_id, example_id)],
         [run],
     ]
-    result = _collect_tool_responses_by_run(client, "exp-name")
+    result = _collect_experiment_traces(client, "exp-name").runs_by_id
     assert result[str(root_id)]["responses"] == ["ORS 90.325 content"]
+
+
+def test_collect_experiment_traces_collects_unique_sorted_queries():
+    """Tool-call query inputs are collected, deduplicated, and sorted."""
+    root_id = uuid4()
+    example_id = uuid4()
+    client = MagicMock()
+    client.read_project.return_value = MagicMock(id=uuid4())
+    client.list_runs.side_effect = [
+        [_make_root_run(root_id, example_id)],
+        [
+            _make_tool_run(root_id, "r1", query="beta query"),
+            _make_tool_run(root_id, "r2", query="alpha query"),
+            _make_tool_run(root_id, "r3", query="beta query"),
+        ],
+    ]
+    assert _collect_experiment_traces(client, "exp-name").queries == [
+        "alpha query",
+        "beta query",
+    ]
 
 
 # ── _check_retrieval_from_traces ───────────────────────────────────────────────
@@ -2098,24 +2119,25 @@ def test_as_utc_aware_converted():
     assert _as_utc(dt) == datetime(2026, 6, 1, 19, 0, 0, tzinfo=timezone.utc)
 
 
-def test_experiment_latest_run_time_returns_max():
-    """Returns the latest start_time across an experiment's root runs."""
+def test_collect_experiment_traces_latest_run_time_returns_max():
+    """latest_run_time is the max start_time across an experiment's root runs."""
     from datetime import datetime
 
     client = MagicMock()
     client.read_project.return_value = MagicMock(id=uuid4())
-    r1 = MagicMock(start_time=datetime(2026, 6, 1, 10, 0, 0))
-    r2 = MagicMock(start_time=datetime(2026, 6, 1, 11, 0, 0))
-    client.list_runs.return_value = [r1, r2]
-    assert _experiment_latest_run_time(client, "exp") == datetime(2026, 6, 1, 11, 0, 0)
+    r1 = MagicMock(start_time=datetime(2026, 6, 1, 10, 0, 0), reference_example_id=None)
+    r2 = MagicMock(start_time=datetime(2026, 6, 1, 11, 0, 0), reference_example_id=None)
+    client.list_runs.side_effect = [[r1, r2], []]  # root-run pass, then tool-run pass
+    traces = _collect_experiment_traces(client, "exp")
+    assert traces.latest_run_time == datetime(2026, 6, 1, 11, 0, 0)
 
 
-def test_experiment_latest_run_time_none_when_no_runs():
-    """Returns None when there are no root runs with start times."""
+def test_collect_experiment_traces_latest_run_time_none_when_no_runs():
+    """latest_run_time is None when there are no root runs with start times."""
     client = MagicMock()
     client.read_project.return_value = MagicMock(id=uuid4())
-    client.list_runs.return_value = []
-    assert _experiment_latest_run_time(client, "exp") is None
+    client.list_runs.side_effect = [[], []]  # root-run pass, then tool-run pass
+    assert _collect_experiment_traces(client, "exp").latest_run_time is None
 
 
 def test_datastore_unchanged_true_when_ds_older_than_experiment():
@@ -2123,19 +2145,14 @@ def test_datastore_unchanged_true_when_ds_older_than_experiment():
     import logging
     from datetime import datetime
 
-    client = MagicMock()
-    with (
-        patch(
-            "evaluate.langsmith_dataset._experiment_latest_run_time",
-            return_value=datetime(2026, 6, 10, 12, 0, 0),
-        ),
-        patch(
-            "evaluate.langsmith_dataset._datastore_last_update_time",
-            return_value=datetime(2026, 6, 1, 12, 0, 0),
-        ),
+    with patch(
+        "evaluate.langsmith_dataset._datastore_last_update_time",
+        return_value=datetime(2026, 6, 1, 12, 0, 0),
     ):
         assert (
-            _datastore_unchanged_since_experiment(client, "exp", logging.getLogger("t"))
+            _datastore_unchanged_since_experiment(
+                datetime(2026, 6, 10, 12, 0, 0), logging.getLogger("t")
+            )
             is True
         )
 
@@ -2145,19 +2162,14 @@ def test_datastore_unchanged_false_when_reindexed_after_experiment():
     import logging
     from datetime import datetime
 
-    client = MagicMock()
-    with (
-        patch(
-            "evaluate.langsmith_dataset._experiment_latest_run_time",
-            return_value=datetime(2026, 6, 1, 12, 0, 0),
-        ),
-        patch(
-            "evaluate.langsmith_dataset._datastore_last_update_time",
-            return_value=datetime(2026, 6, 10, 12, 0, 0),
-        ),
+    with patch(
+        "evaluate.langsmith_dataset._datastore_last_update_time",
+        return_value=datetime(2026, 6, 10, 12, 0, 0),
     ):
         assert (
-            _datastore_unchanged_since_experiment(client, "exp", logging.getLogger("t"))
+            _datastore_unchanged_since_experiment(
+                datetime(2026, 6, 1, 12, 0, 0), logging.getLogger("t")
+            )
             is False
         )
 
@@ -2166,20 +2178,12 @@ def test_datastore_unchanged_false_when_timing_unavailable():
     """Falls open (False) when either timestamp can't be determined."""
     import logging
 
-    client = MagicMock()
-    with (
-        patch(
-            "evaluate.langsmith_dataset._experiment_latest_run_time",
-            return_value=None,
-        ),
-        patch(
-            "evaluate.langsmith_dataset._datastore_last_update_time",
-            return_value=None,
-        ),
+    with patch(
+        "evaluate.langsmith_dataset._datastore_last_update_time",
+        return_value=None,
     ):
         assert (
-            _datastore_unchanged_since_experiment(client, "exp", logging.getLogger("t"))
-            is False
+            _datastore_unchanged_since_experiment(None, logging.getLogger("t")) is False
         )
 
 

--- a/backend/tests/test_langsmith_dataset.py
+++ b/backend/tests/test_langsmith_dataset.py
@@ -17,8 +17,8 @@ from evaluate.langsmith_dataset import (
     _check_retrieval_from_traces,
     _collect_tool_responses_by_run,
     _datastore_unchanged_since_experiment,
-    _experiment_latest_run_time,
     _example_content_diff,
+    _experiment_latest_run_time,
     _experiment_scores,
     _extract_rubric,
     _git_is_clean,
@@ -1871,13 +1871,21 @@ def test_check_retrieval_retirement_candidate(caplog):
     import logging
 
     eid = str(uuid4())
-    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    stopgaps = [
+        _make_stopgap(
+            "ORS 90.425 personal property", ["landlord must give a written notice"]
+        )
+    ]
     runs_by_id = {
-        str(uuid4()): _make_run_entry(eid, ["...landlord must give a written notice to the tenant..."])
+        str(uuid4()): _make_run_entry(
+            eid, ["...landlord must give a written notice to the tenant..."]
+        )
     }
     facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
     with caplog.at_level(logging.INFO):
-        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+        _check_retrieval_from_traces(
+            stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval")
+        )
     assert any("retirement candidate" in r.message for r in caplog.records)
 
 
@@ -1886,11 +1894,21 @@ def test_check_retrieval_never_retrieved(caplog):
     import logging
 
     eid = str(uuid4())
-    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
-    runs_by_id = {str(uuid4()): _make_run_entry(eid, ["completely unrelated retrieved text about rent"])}
+    stopgaps = [
+        _make_stopgap(
+            "ORS 90.425 personal property", ["landlord must give a written notice"]
+        )
+    ]
+    runs_by_id = {
+        str(uuid4()): _make_run_entry(
+            eid, ["completely unrelated retrieved text about rent"]
+        )
+    }
     facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
     with caplog.at_level(logging.INFO):
-        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+        _check_retrieval_from_traces(
+            stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval")
+        )
     assert any("never retrieved" in r.message for r in caplog.records)
 
 
@@ -1899,15 +1917,23 @@ def test_check_retrieval_partially_retrieved(caplog):
     import logging
 
     eid = str(uuid4())
-    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    stopgaps = [
+        _make_stopgap(
+            "ORS 90.425 personal property", ["landlord must give a written notice"]
+        )
+    ]
     # Two repetitions of the same scenario; one retrieves the target, one does not.
     runs_by_id = {
-        str(uuid4()): _make_run_entry(eid, ["...landlord must give a written notice..."]),
+        str(uuid4()): _make_run_entry(
+            eid, ["...landlord must give a written notice..."]
+        ),
         str(uuid4()): _make_run_entry(eid, ["unrelated text about security deposits"]),
     }
     facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
     with caplog.at_level(logging.INFO):
-        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+        _check_retrieval_from_traces(
+            stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval")
+        )
     assert any("partially retrieved" in r.message for r in caplog.records)
     assert any("1/2" in r.message for r in caplog.records)
 
@@ -1917,7 +1943,11 @@ def test_check_retrieval_counts_each_repetition_once(caplog):
     import logging
 
     eid = str(uuid4())
-    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    stopgaps = [
+        _make_stopgap(
+            "ORS 90.425 personal property", ["landlord must give a written notice"]
+        )
+    ]
     # A single repetition made two RAG calls; the target appears in only one.
     runs_by_id = {
         str(uuid4()): _make_run_entry(
@@ -1927,7 +1957,9 @@ def test_check_retrieval_counts_each_repetition_once(caplog):
     }
     facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
     with caplog.at_level(logging.INFO):
-        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+        _check_retrieval_from_traces(
+            stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval")
+        )
     # One repetition, one hit — not 1/2 across the two tool calls.
     assert any("retirement candidate" in r.message for r in caplog.records)
     assert any("1/1" in r.message for r in caplog.records)
@@ -1939,9 +1971,15 @@ def test_check_retrieval_filters_to_relevant_examples(caplog):
 
     relevant_eid = str(uuid4())
     irrelevant_eid = str(uuid4())
-    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    stopgaps = [
+        _make_stopgap(
+            "ORS 90.425 personal property", ["landlord must give a written notice"]
+        )
+    ]
     runs_by_id = {
-        str(uuid4()): _make_run_entry(relevant_eid, ["...landlord must give a written notice..."]),
+        str(uuid4()): _make_run_entry(
+            relevant_eid, ["...landlord must give a written notice..."]
+        ),
         str(uuid4()): _make_run_entry(irrelevant_eid, ["unrelated text"]),
     }
     facts_by_example = {
@@ -1949,7 +1987,9 @@ def test_check_retrieval_filters_to_relevant_examples(caplog):
         irrelevant_eid: ["Question pertains to ORS 90.394"],
     }
     with caplog.at_level(logging.INFO):
-        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+        _check_retrieval_from_traces(
+            stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval")
+        )
     # The irrelevant repetition missed, but it's excluded — only the relevant one counts.
     assert any("retirement candidate" in r.message for r in caplog.records)
     assert any("1/1" in r.message for r in caplog.records)
@@ -1960,11 +2000,17 @@ def test_check_retrieval_no_relevant_scenarios(caplog):
     import logging
 
     eid = str(uuid4())
-    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    stopgaps = [
+        _make_stopgap(
+            "ORS 90.425 personal property", ["landlord must give a written notice"]
+        )
+    ]
     runs_by_id = {str(uuid4()): _make_run_entry(eid, ["some retrieved text"])}
     facts_by_example = {eid: ["Question pertains to ORS 90.394"]}
     with caplog.at_level(logging.INFO):
-        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+        _check_retrieval_from_traces(
+            stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval")
+        )
     assert any("no relevant scenarios" in r.message for r in caplog.records)
 
 
@@ -1973,12 +2019,22 @@ def test_check_retrieval_normalizes_whitespace(caplog):
     import logging
 
     eid = str(uuid4())
-    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    stopgaps = [
+        _make_stopgap(
+            "ORS 90.425 personal property", ["landlord must give a written notice"]
+        )
+    ]
     # Corpus text has a line break in the middle of the target phrase.
-    runs_by_id = {str(uuid4()): _make_run_entry(eid, ["...landlord must give a written\nnotice to the tenant..."])}
+    runs_by_id = {
+        str(uuid4()): _make_run_entry(
+            eid, ["...landlord must give a written\nnotice to the tenant..."]
+        )
+    }
     facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
     with caplog.at_level(logging.INFO):
-        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+        _check_retrieval_from_traces(
+            stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval")
+        )
     assert any("retirement candidate" in r.message for r in caplog.records)
 
 
@@ -1988,7 +2044,9 @@ def test_check_retrieval_empty_runs_does_not_raise(caplog):
 
     stopgaps = [_make_stopgap("ORS 90.425 personal property", ["some target"])]
     with caplog.at_level(logging.INFO):
-        _check_retrieval_from_traces(stopgaps, {}, {}, logging.getLogger("test_retrieval"))
+        _check_retrieval_from_traces(
+            stopgaps, {}, {}, logging.getLogger("test_retrieval")
+        )
     # No relevant repetitions exist, so the STOPGAP is reported as having no coverage.
     assert any("no relevant scenarios" in r.message for r in caplog.records)
 

--- a/backend/tests/test_langsmith_dataset.py
+++ b/backend/tests/test_langsmith_dataset.py
@@ -13,6 +13,11 @@ from hypothesis import strategies as st
 from evaluate.langsmith_dataset import (
     RETENTION_DAYS,
     _apply_dataset_schemas,
+    _as_utc,
+    _check_retrieval_from_traces,
+    _collect_tool_responses_by_run,
+    _datastore_unchanged_since_experiment,
+    _experiment_latest_run_time,
     _example_content_diff,
     _experiment_scores,
     _extract_rubric,
@@ -1724,6 +1729,400 @@ def test_cmd_run_trace_verbose_recurses_into_child_runs(capsys):
     assert "parent-chain" in out
     assert "child-tool" in out
     assert "child input" in out
+
+
+# ── _collect_tool_responses_by_run ────────────────────────────────────────────
+
+
+def _make_root_run(run_id, example_id):
+    run = MagicMock()
+    run.id = run_id
+    run.reference_example_id = example_id
+    return run
+
+
+def _make_tool_run(trace_id, output_text):
+    run = MagicMock()
+    run.trace_id = trace_id
+    run.outputs = {"output": output_text}
+    return run
+
+
+def test_collect_tool_responses_groups_by_run():
+    """Responses are grouped under their root run ID, tagged with the example ID."""
+    root_id = uuid4()
+    example_id = uuid4()
+    client = MagicMock()
+    client.read_project.return_value = MagicMock(id=uuid4())
+    client.list_runs.side_effect = [
+        [_make_root_run(root_id, example_id)],
+        [_make_tool_run(root_id, "ORS 90.425 text here")],
+    ]
+    result = _collect_tool_responses_by_run(client, "exp-name")
+    assert str(root_id) in result
+    assert result[str(root_id)]["example_id"] == str(example_id)
+    assert result[str(root_id)]["responses"] == ["ORS 90.425 text here"]
+
+
+def test_collect_tool_responses_multiple_calls_same_run():
+    """Multiple tool calls within the same repetition are all collected."""
+    root_id = uuid4()
+    example_id = uuid4()
+    client = MagicMock()
+    client.read_project.return_value = MagicMock(id=uuid4())
+    client.list_runs.side_effect = [
+        [_make_root_run(root_id, example_id)],
+        [
+            _make_tool_run(root_id, "first response"),
+            _make_tool_run(root_id, "second response"),
+        ],
+    ]
+    result = _collect_tool_responses_by_run(client, "exp-name")
+    assert len(result[str(root_id)]["responses"]) == 2
+
+
+def test_collect_tool_responses_separates_repetitions_of_same_example():
+    """Two repetitions of the same example are kept as distinct entries."""
+    root_id_a = uuid4()
+    root_id_b = uuid4()
+    example_id = uuid4()
+    client = MagicMock()
+    client.read_project.return_value = MagicMock(id=uuid4())
+    client.list_runs.side_effect = [
+        [
+            _make_root_run(root_id_a, example_id),
+            _make_root_run(root_id_b, example_id),
+        ],
+        [
+            _make_tool_run(root_id_a, "rep A response"),
+            _make_tool_run(root_id_b, "rep B response"),
+        ],
+    ]
+    result = _collect_tool_responses_by_run(client, "exp-name")
+    assert len(result) == 2
+    assert result[str(root_id_a)]["example_id"] == str(example_id)
+    assert result[str(root_id_b)]["example_id"] == str(example_id)
+
+
+def test_collect_tool_responses_skips_unmatched_trace_id():
+    """Tool runs whose trace_id has no matching root run are ignored."""
+    root_id = uuid4()
+    example_id = uuid4()
+    orphan_id = uuid4()
+    client = MagicMock()
+    client.read_project.return_value = MagicMock(id=uuid4())
+    client.list_runs.side_effect = [
+        [_make_root_run(root_id, example_id)],
+        [
+            _make_tool_run(root_id, "matched response"),
+            _make_tool_run(orphan_id, "unmatched response"),
+        ],
+    ]
+    result = _collect_tool_responses_by_run(client, "exp-name")
+    assert len(result) == 1
+    assert result[str(root_id)]["responses"] == ["matched response"]
+
+
+def test_collect_tool_responses_skips_empty_output():
+    """Tool runs with empty or missing output text are skipped."""
+    root_id = uuid4()
+    example_id = uuid4()
+    empty_run = _make_tool_run(root_id, "")
+    empty_run.outputs = {}
+    client = MagicMock()
+    client.read_project.return_value = MagicMock(id=uuid4())
+    client.list_runs.side_effect = [
+        [_make_root_run(root_id, example_id)],
+        [empty_run],
+    ]
+    result = _collect_tool_responses_by_run(client, "exp-name")
+    assert result == {}
+
+
+def test_collect_tool_responses_accepts_content_key():
+    """Output stored under 'content' key (fallback) is also captured."""
+    root_id = uuid4()
+    example_id = uuid4()
+    run = _make_tool_run(root_id, "")
+    run.outputs = {"content": "ORS 90.325 content"}
+    client = MagicMock()
+    client.read_project.return_value = MagicMock(id=uuid4())
+    client.list_runs.side_effect = [
+        [_make_root_run(root_id, example_id)],
+        [run],
+    ]
+    result = _collect_tool_responses_by_run(client, "exp-name")
+    assert result[str(root_id)]["responses"] == ["ORS 90.325 content"]
+
+
+# ── _check_retrieval_from_traces ───────────────────────────────────────────────
+
+
+def _make_stopgap(label: str, targets: list[str]) -> dict:
+    return {"label": label, "targets": targets}
+
+
+def _make_run_entry(example_id: str, responses: list[str]) -> dict:
+    return {"example_id": example_id, "responses": responses}
+
+
+def test_check_retrieval_retirement_candidate(caplog):
+    """Every relevant repetition contains the target text → retirement candidate."""
+    import logging
+
+    eid = str(uuid4())
+    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    runs_by_id = {
+        str(uuid4()): _make_run_entry(eid, ["...landlord must give a written notice to the tenant..."])
+    }
+    facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
+    with caplog.at_level(logging.INFO):
+        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+    assert any("retirement candidate" in r.message for r in caplog.records)
+
+
+def test_check_retrieval_never_retrieved(caplog):
+    """No relevant repetition contains the target text → never retrieved."""
+    import logging
+
+    eid = str(uuid4())
+    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    runs_by_id = {str(uuid4()): _make_run_entry(eid, ["completely unrelated retrieved text about rent"])}
+    facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
+    with caplog.at_level(logging.INFO):
+        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+    assert any("never retrieved" in r.message for r in caplog.records)
+
+
+def test_check_retrieval_partially_retrieved(caplog):
+    """Some but not all repetitions of a relevant scenario hit → partially retrieved."""
+    import logging
+
+    eid = str(uuid4())
+    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    # Two repetitions of the same scenario; one retrieves the target, one does not.
+    runs_by_id = {
+        str(uuid4()): _make_run_entry(eid, ["...landlord must give a written notice..."]),
+        str(uuid4()): _make_run_entry(eid, ["unrelated text about security deposits"]),
+    }
+    facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
+    with caplog.at_level(logging.INFO):
+        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+    assert any("partially retrieved" in r.message for r in caplog.records)
+    assert any("1/2" in r.message for r in caplog.records)
+
+
+def test_check_retrieval_counts_each_repetition_once(caplog):
+    """A repetition with multiple tool calls counts as one hit if any call matches."""
+    import logging
+
+    eid = str(uuid4())
+    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    # A single repetition made two RAG calls; the target appears in only one.
+    runs_by_id = {
+        str(uuid4()): _make_run_entry(
+            eid,
+            ["miss on this call", "...landlord must give a written notice..."],
+        )
+    }
+    facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
+    with caplog.at_level(logging.INFO):
+        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+    # One repetition, one hit — not 1/2 across the two tool calls.
+    assert any("retirement candidate" in r.message for r in caplog.records)
+    assert any("1/1" in r.message for r in caplog.records)
+
+
+def test_check_retrieval_filters_to_relevant_examples(caplog):
+    """Repetitions of examples whose facts don't mention the ORS are excluded."""
+    import logging
+
+    relevant_eid = str(uuid4())
+    irrelevant_eid = str(uuid4())
+    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    runs_by_id = {
+        str(uuid4()): _make_run_entry(relevant_eid, ["...landlord must give a written notice..."]),
+        str(uuid4()): _make_run_entry(irrelevant_eid, ["unrelated text"]),
+    }
+    facts_by_example = {
+        relevant_eid: ["Question pertains to ORS 90.425"],
+        irrelevant_eid: ["Question pertains to ORS 90.394"],
+    }
+    with caplog.at_level(logging.INFO):
+        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+    # The irrelevant repetition missed, but it's excluded — only the relevant one counts.
+    assert any("retirement candidate" in r.message for r in caplog.records)
+    assert any("1/1" in r.message for r in caplog.records)
+
+
+def test_check_retrieval_no_relevant_scenarios(caplog):
+    """No examples whose facts mention the ORS → logs 'no relevant scenarios'."""
+    import logging
+
+    eid = str(uuid4())
+    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    runs_by_id = {str(uuid4()): _make_run_entry(eid, ["some retrieved text"])}
+    facts_by_example = {eid: ["Question pertains to ORS 90.394"]}
+    with caplog.at_level(logging.INFO):
+        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+    assert any("no relevant scenarios" in r.message for r in caplog.records)
+
+
+def test_check_retrieval_normalizes_whitespace(caplog):
+    """Target phrase with internal newlines in corpus text still matches."""
+    import logging
+
+    eid = str(uuid4())
+    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give a written notice"])]
+    # Corpus text has a line break in the middle of the target phrase.
+    runs_by_id = {str(uuid4()): _make_run_entry(eid, ["...landlord must give a written\nnotice to the tenant..."])}
+    facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
+    with caplog.at_level(logging.INFO):
+        _check_retrieval_from_traces(stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval"))
+    assert any("retirement candidate" in r.message for r in caplog.records)
+
+
+def test_check_retrieval_empty_runs_does_not_raise(caplog):
+    """Empty runs_by_id is handled gracefully without raising."""
+    import logging
+
+    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["some target"])]
+    with caplog.at_level(logging.INFO):
+        _check_retrieval_from_traces(stopgaps, {}, {}, logging.getLogger("test_retrieval"))
+    # No relevant repetitions exist, so the STOPGAP is reported as having no coverage.
+    assert any("no relevant scenarios" in r.message for r in caplog.records)
+
+
+def test_check_retrieval_returns_coverage_gap():
+    """A STOPGAP with no relevant repetitions makes the function report a coverage gap."""
+    import logging
+
+    eid = str(uuid4())
+    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["some target"])]
+    runs_by_id = {str(uuid4()): _make_run_entry(eid, ["unrelated"])}
+    facts_by_example = {eid: ["Question pertains to ORS 90.394"]}
+    gap = _check_retrieval_from_traces(
+        stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval")
+    )
+    assert gap is True
+
+
+def test_check_retrieval_no_coverage_gap_when_all_covered():
+    """When every STOPGAP has relevant repetitions, no coverage gap is reported."""
+    import logging
+
+    eid = str(uuid4())
+    stopgaps = [_make_stopgap("ORS 90.425 personal property", ["landlord must give"])]
+    runs_by_id = {str(uuid4()): _make_run_entry(eid, ["landlord must give notice"])}
+    facts_by_example = {eid: ["Question pertains to ORS 90.425"]}
+    gap = _check_retrieval_from_traces(
+        stopgaps, runs_by_id, facts_by_example, logging.getLogger("test_retrieval")
+    )
+    assert gap is False
+
+
+# ── datastore short-circuit ───────────────────────────────────────────────────
+
+
+def test_as_utc_naive_assumed_utc():
+    """A naive datetime is treated as UTC."""
+    from datetime import datetime, timezone
+
+    dt = datetime(2026, 6, 1, 12, 0, 0)
+    assert _as_utc(dt) == datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_as_utc_aware_converted():
+    """An aware datetime is converted to UTC."""
+    from datetime import datetime, timedelta, timezone
+
+    dt = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=-7)))
+    assert _as_utc(dt) == datetime(2026, 6, 1, 19, 0, 0, tzinfo=timezone.utc)
+
+
+def test_experiment_latest_run_time_returns_max():
+    """Returns the latest start_time across an experiment's root runs."""
+    from datetime import datetime
+
+    client = MagicMock()
+    client.read_project.return_value = MagicMock(id=uuid4())
+    r1 = MagicMock(start_time=datetime(2026, 6, 1, 10, 0, 0))
+    r2 = MagicMock(start_time=datetime(2026, 6, 1, 11, 0, 0))
+    client.list_runs.return_value = [r1, r2]
+    assert _experiment_latest_run_time(client, "exp") == datetime(2026, 6, 1, 11, 0, 0)
+
+
+def test_experiment_latest_run_time_none_when_no_runs():
+    """Returns None when there are no root runs with start times."""
+    client = MagicMock()
+    client.read_project.return_value = MagicMock(id=uuid4())
+    client.list_runs.return_value = []
+    assert _experiment_latest_run_time(client, "exp") is None
+
+
+def test_datastore_unchanged_true_when_ds_older_than_experiment():
+    """Datastore last-update before the experiment ran → unchanged → True."""
+    import logging
+    from datetime import datetime
+
+    client = MagicMock()
+    with (
+        patch(
+            "evaluate.langsmith_dataset._experiment_latest_run_time",
+            return_value=datetime(2026, 6, 10, 12, 0, 0),
+        ),
+        patch(
+            "evaluate.langsmith_dataset._datastore_last_update_time",
+            return_value=datetime(2026, 6, 1, 12, 0, 0),
+        ),
+    ):
+        assert (
+            _datastore_unchanged_since_experiment(client, "exp", logging.getLogger("t"))
+            is True
+        )
+
+
+def test_datastore_unchanged_false_when_reindexed_after_experiment():
+    """Datastore reindexed after the experiment ran → changed → False."""
+    import logging
+    from datetime import datetime
+
+    client = MagicMock()
+    with (
+        patch(
+            "evaluate.langsmith_dataset._experiment_latest_run_time",
+            return_value=datetime(2026, 6, 1, 12, 0, 0),
+        ),
+        patch(
+            "evaluate.langsmith_dataset._datastore_last_update_time",
+            return_value=datetime(2026, 6, 10, 12, 0, 0),
+        ),
+    ):
+        assert (
+            _datastore_unchanged_since_experiment(client, "exp", logging.getLogger("t"))
+            is False
+        )
+
+
+def test_datastore_unchanged_false_when_timing_unavailable():
+    """Falls open (False) when either timestamp can't be determined."""
+    import logging
+
+    client = MagicMock()
+    with (
+        patch(
+            "evaluate.langsmith_dataset._experiment_latest_run_time",
+            return_value=None,
+        ),
+        patch(
+            "evaluate.langsmith_dataset._datastore_last_update_time",
+            return_value=None,
+        ),
+    ):
+        assert (
+            _datastore_unchanged_since_experiment(client, "exp", logging.getLogger("t"))
+            is False
+        )
 
 
 # ── _message_text ──────────────────────────────────────────────────────────────

--- a/backend/tests/test_measure_evaluator_variance.py
+++ b/backend/tests/test_measure_evaluator_variance.py
@@ -184,7 +184,7 @@ def test_measure_evaluator_variance_calls_evaluator_k_times(fake_pairs):
         ),
         patch(
             "evaluate.measure_evaluator_variance._ALL_EVALUATORS",
-            {"legal correctness": mock_evaluator},
+            {"legal correctness": lambda: mock_evaluator},
         ),
         patch("evaluate.measure_evaluator_variance.Client"),
         patch("evaluate.measure_evaluator_variance.print_consistency_stats"),
@@ -213,7 +213,7 @@ def test_measure_evaluator_variance_scenario_filter(fake_pairs):
         ),
         patch(
             "evaluate.measure_evaluator_variance._ALL_EVALUATORS",
-            {"legal correctness": mock_evaluator},
+            {"legal correctness": lambda: mock_evaluator},
         ),
         patch("evaluate.measure_evaluator_variance.Client"),
         patch("evaluate.measure_evaluator_variance.print_consistency_stats"),
@@ -235,7 +235,7 @@ def test_measure_evaluator_variance_runs_per_scenario_limit(fake_pairs):
         ),
         patch(
             "evaluate.measure_evaluator_variance._ALL_EVALUATORS",
-            {"legal correctness": mock_evaluator},
+            {"legal correctness": lambda: mock_evaluator},
         ),
         patch("evaluate.measure_evaluator_variance.Client"),
         patch("evaluate.measure_evaluator_variance.print_consistency_stats"),
@@ -289,7 +289,7 @@ def test_measure_evaluator_variance_results_collected_from_threads(fake_pairs):
         ),
         patch(
             "evaluate.measure_evaluator_variance._ALL_EVALUATORS",
-            {"legal correctness": original_evaluator},
+            {"legal correctness": lambda: original_evaluator},
         ),
         patch("evaluate.measure_evaluator_variance.Client"),
         patch(
@@ -325,7 +325,7 @@ def test_measure_evaluator_variance_thread_error_does_not_abort(fake_pairs):
         ),
         patch(
             "evaluate.measure_evaluator_variance._ALL_EVALUATORS",
-            {"legal correctness": flaky_evaluator},
+            {"legal correctness": lambda: flaky_evaluator},
         ),
         patch("evaluate.measure_evaluator_variance.Client"),
         patch("evaluate.measure_evaluator_variance.print_consistency_stats"),
@@ -348,7 +348,7 @@ def test_measure_evaluator_variance_calls_write_variance_entry(fake_pairs):
         ),
         patch(
             "evaluate.measure_evaluator_variance._ALL_EVALUATORS",
-            {"legal correctness": mock_evaluator},
+            {"legal correctness": lambda: mock_evaluator},
         ),
         patch("evaluate.measure_evaluator_variance.Client"),
         patch("evaluate.measure_evaluator_variance.print_consistency_stats"),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Infrastructure
- [ ] Maintenance

## Description

This adds an `/optimize-experiment <experiment-name>` skill with the associated tools so that Claude can do a static analysis of traces from an experiment.  It can also compare the tool calls/results from an experiment on a new datastore to determine whether hacks/workarounds in the system prompt can be removed.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue
  - weak dependency on #373
  - since this touches `evaluation.md`, probably want to wait for #379 
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note on the devices and browsers this has been tested on, as well as any relevant images for UI changes._


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?
