### PR TITLE
Session storage chat and letter message history

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Tenant First Aid is a chatbot application that provides legal information related to housing and eviction in Oregon. The system uses a Retrieval-Augmented Generation (RAG) architecture to provide accurate, contextual responses based on Oregon housing law documents.  The LangChain framework is used to abstract models and agents.
+Tenant First Aid is a chatbot application that provides legal information related to housing and eviction in Oregon. The system uses a Retrieval-Augmented Generation (RAG) architecture to provide accurate, contextual responses based on Oregon housing law documents. The LangChain framework is used to abstract models and agents.
 
 The application follows a modern web architecture with a Flask-based Python backend serving a React frontend, deployed on Digital Ocean infrastructure.
 
@@ -77,6 +77,8 @@ reading paths (new reader, backend contributor, corpus operator):
 
 The frontend is a modern React application built with TypeScript and Vite. It provides a clean, accessible chat interface for users to interact with the legal advice chatbot.
 
+**Client-Side Message Persistence:** `useMessages` accepts an optional `storageKey`. When given, it loads message state from `sessionStorage` on mount and syncs every state change back to it, so a chat or letter conversation survives a page refresh within the same browser tab session. Chat pages key storage by jurisdiction (`chat_messages:<jurisdiction>`); letter pages key it by jurisdiction and referring org (`letter_messages:<jurisdiction>,<org>`), so switching location or partner link starts a fresh conversation rather than reusing a stale one.
+
 ### Directory/File Structure
 
 ```
@@ -95,7 +97,7 @@ frontend/
 │   │   └── HousingContext.tsx      # Housing context for chat/letter generation
 │   ├── hooks/                      # Custom React hooks
 │   │   ├── useIsMobile.tsx         # Checking mobile state
-│   │   ├── useMessages.tsx         # Message handling logic
+│   │   ├── useMessages.tsx         # Message handling + persistence logic
 │   │   ├── useHousingContext.tsx   # Custom hook for housing context
 │   │   └── useLetterContent.tsx    # State management for letter generation
 │   ├── generated/                  # Auto-generated frontend data (gitignored)
@@ -148,7 +150,8 @@ frontend/
 │   │       ├── buildLocationPrefix.ts # Helper function for location prefix
 │   │       ├── scrolling.ts        # Helper function for window scrolling
 │   │       ├── dompurify.ts        # Helper function for sanitizing text
-│   │       └── formatLocation.ts   # Formats OregonCity/UsaState into a display string (e.g. "Portland, OR")
+│   │       ├── formatLocation.ts   # Formats OregonCity/UsaState into a display string (e.g. "Portland, OR")
+│   │       └── reloadPage.ts       # Wrapper around window.location.reload()
 │   └── tests/                     # Testing suite
 │   │   ├── components/            # Component testing
 │   │   │   ├── About.test.tsx     # About component testing

--- a/Architecture.md
+++ b/Architecture.md
@@ -77,7 +77,9 @@ reading paths (new reader, backend contributor, corpus operator):
 
 The frontend is a modern React application built with TypeScript and Vite. It provides a clean, accessible chat interface for users to interact with the legal advice chatbot.
 
-**Client-Side Message Persistence:** `useMessages` accepts an optional `storageKey`. When given, it loads message state from `sessionStorage` on mount and syncs every state change back to it, so a chat or letter conversation survives a page refresh within the same browser tab session. Chat pages key storage by jurisdiction (`chat_messages:<jurisdiction>`); letter pages key it by jurisdiction and referring org (`letter_messages:<jurisdiction>,<org>`), so switching location or partner link starts a fresh conversation rather than reusing a stale one.
+**Client-Side Message Persistence:** `useMessages` accepts an optional `storageKey`. When given, it loads message state from `sessionStorage` on mount and syncs every state change back to it, so a chat or letter conversation can survive a page refresh without being saved to the server. Chat pages key storage by jurisdiction (`chat_messages:<jurisdiction>`); letter pages key it by jurisdiction and referring org (`letter_messages:<jurisdiction>,<org>`), so switching location or partner link starts a fresh conversation rather than reusing a stale one. The messages normally remain available for the browser-tab session; on a public device, they are removed early if the inactivity warning expires.
+
+**Device Privacy:** `DevicePrivacyGuard` asks each browser-tab session whether the device is public or private. On public devices, five minutes without user activity opens a 120-second warning. If the warning expires, the guard removes the device-privacy choice and all `chat_messages:*` and `letter_messages:*` entries from `sessionStorage`, then attempts to close the page and redirects to the home page when the browser blocks scripted closing. Cleanup is intentionally limited to Tenant First Aid's known keys so other applications' session data is not removed.
 
 ### Directory/File Structure
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -4032,7 +4032,7 @@ wheels = [
 ]
 
 [[package]]
-name = "tenant-first-aid"
+name = "tenantfirstaid"
 version = "0.5.0"
 source = { editable = "." }
 dependencies = [

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,49 +18,37 @@ const Letter = lazy(() => import("./Letter"));
 export default function App() {
   return (
     <Router>
-      <Navbar />
-      <RegionNotice />
-      <PageLayout>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route
-            path="/*"
-            element={
-              <Suspense fallback={<LoadingPage />}>
-                <Routes>
-                  <Route
-                    path="/chat/:state?/:city?"
-                    element={
-                      <DevicePrivacyGuard>
-                        <Chat />
-                      </DevicePrivacyGuard>
-                    }
-                  />
-                  <Route
-                    path="/letter/:state?/:city?"
-                    element={
-                      <DevicePrivacyGuard>
-                        <Letter />
-                      </DevicePrivacyGuard>
-                    }
-                  />
-                  <Route path="/about" element={<About />} />
-                  <Route path="/disclaimer" element={<Disclaimer />} />
-                  <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-                  <Route path="/referrals" element={<Referrals />} />
-                </Routes>
-              </Suspense>
-            }
-          />
-        </Routes>
-      </PageLayout>
-      <footer className="fixed bottom-0 left-0 w-full h-(--footer-height) bg-paper-background border-t border-gray-light flex items-center justify-end px-4 text-xs text-gray-dark z-40">
-        <span>
-          &copy; {new Date().getFullYear()} Tenant First Aid
-          <span className="mx-2">|</span>
-          UI Version {__APP_VERSION__}
-        </span>
-      </footer>
+      <DevicePrivacyGuard>
+        <Navbar />
+        <RegionNotice />
+        <PageLayout>
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route
+              path="/*"
+              element={
+                <Suspense fallback={<LoadingPage />}>
+                  <Routes>
+                    <Route path="/chat/:state?/:city?" element={<Chat />} />
+                    <Route path="/letter/:state?/:city?" element={<Letter />} />
+                    <Route path="/about" element={<About />} />
+                    <Route path="/disclaimer" element={<Disclaimer />} />
+                    <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+                    <Route path="/referrals" element={<Referrals />} />
+                  </Routes>
+                </Suspense>
+              }
+            />
+          </Routes>
+        </PageLayout>
+        <footer className="fixed bottom-0 left-0 w-full h-(--footer-height) bg-paper-background border-t border-gray-light flex items-center justify-end px-4 text-xs text-gray-dark z-40">
+          <span>
+            &copy; {new Date().getFullYear()} Tenant First Aid
+            <span className="mx-2">|</span>
+            UI Version {__APP_VERSION__}
+          </span>
+        </footer>
+      </DevicePrivacyGuard>
     </Router>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Chat from "./Chat";
 import LoadingPage from "./pages/LoadingPage";
 import PageLayout from "./layouts/PageLayout";
 import HomePage from "./pages/HomePage/HomePage";
+import DevicePrivacyGuard from "./shared/components/DevicePrivacyGuard";
 
 // Lazy-loading for less frequented pages
 const About = lazy(() => import("./About"));
@@ -27,8 +28,22 @@ export default function App() {
             element={
               <Suspense fallback={<LoadingPage />}>
                 <Routes>
-                  <Route path="/chat/:state?/:city?" element={<Chat />} />
-                  <Route path="/letter/:state?/:city?" element={<Letter />} />
+                  <Route
+                    path="/chat/:state?/:city?"
+                    element={
+                      <DevicePrivacyGuard>
+                        <Chat />
+                      </DevicePrivacyGuard>
+                    }
+                  />
+                  <Route
+                    path="/letter/:state?/:city?"
+                    element={
+                      <DevicePrivacyGuard>
+                        <Letter />
+                      </DevicePrivacyGuard>
+                    }
+                  />
                   <Route path="/about" element={<About />} />
                   <Route path="/disclaimer" element={<Disclaimer />} />
                   <Route path="/privacy-policy" element={<PrivacyPolicy />} />

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -8,7 +8,11 @@ import MessageContainer from "./shared/components/MessageContainer";
 import FeaturesPanel from "./shared/components/FeaturesPanel";
 import MobilePanel from "./shared/components/MobilePanel";
 import { Navigate, useParams } from "react-router-dom";
-import { classifyStateSegment, pathFor } from "./shared/utils/jurisdiction";
+import {
+  classifyStateSegment,
+  pathFor,
+  resolveJurisdiction,
+} from "./shared/utils/jurisdiction";
 import { DEFAULT_JURISDICTION } from "./shared/constants/jurisdictions";
 import clsx from "clsx";
 
@@ -41,7 +45,11 @@ export default function Chat() {
 
 function ChatView() {
   useSyncJurisdiction();
-  const { addMessage, messages, setMessages } = useMessages();
+  const { state, city } = useParams();
+  const jurisdiction = resolveJurisdiction(state, city);
+  const { addMessage, messages, setMessages, clearMessages } = useMessages(
+    `chat_messages:${jurisdiction.key}`,
+  );
   const isOngoing = messages.length > 0;
   const { letterContent } = useLetterContent(messages);
 
@@ -57,10 +65,12 @@ function ChatView() {
             )}
           >
             <MessageWindow
+              mode="chat"
               messages={messages}
               addMessage={addMessage}
               setMessages={setMessages}
               isOngoing={isOngoing}
+              clearMessages={clearMessages}
             />
           </div>
         </MessageContainer>

--- a/frontend/src/Chat.tsx
+++ b/frontend/src/Chat.tsx
@@ -1,5 +1,5 @@
 import MessageWindow from "./pages/Chat/components/MessageWindow";
-import useMessages from "./hooks/useMessages";
+import useMessages, { CHAT_MESSAGES_STORAGE_PREFIX } from "./hooks/useMessages";
 import useSyncJurisdiction from "./hooks/useSyncJurisdiction";
 import { useLetterContent } from "./hooks/useLetterContent";
 import ChatDisclaimer from "./pages/Chat/components/ChatDisclaimer";
@@ -48,7 +48,7 @@ function ChatView() {
   const { state, city } = useParams();
   const jurisdiction = resolveJurisdiction(state, city);
   const { addMessage, messages, setMessages, clearMessages } = useMessages(
-    `chat_messages:${jurisdiction.key}`,
+    `${CHAT_MESSAGES_STORAGE_PREFIX}${jurisdiction.key}`,
   );
   const isOngoing = messages.length > 0;
   const { letterContent } = useLetterContent(messages);

--- a/frontend/src/Letter.tsx
+++ b/frontend/src/Letter.tsx
@@ -1,7 +1,9 @@
 import { HumanMessage } from "@langchain/core/messages";
 import type { UiMessage } from "./shared/types/messages";
 import MessageWindow from "./pages/Chat/components/MessageWindow";
-import useMessages from "./hooks/useMessages";
+import useMessages, {
+  LETTER_MESSAGES_STORAGE_PREFIX,
+} from "./hooks/useMessages";
 import { useEffect, useRef, useState } from "react";
 import { Navigate, useParams, useSearchParams } from "react-router-dom";
 import { useLetterContent } from "./hooks/useLetterContent";
@@ -83,7 +85,7 @@ interface LetterViewProps {
 
 function LetterView({ jurisdiction, org }: LetterViewProps) {
   const { addMessage, messages, setMessages, clearMessages } = useMessages(
-    `letter_messages:${jurisdiction.key},${org ?? ""}`,
+    `${LETTER_MESSAGES_STORAGE_PREFIX}${jurisdiction.key},${org ?? ""}`,
   );
   const isOngoing = messages.length > 0;
   const { letterContent } = useLetterContent(messages);
@@ -91,6 +93,9 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
   const streamLocationRef = useRef<Location | null>(null);
   const [isGenerating, setIsGenerating] = useState(letterContent === "");
   const dialogRef = useRef<HTMLDialogElement>(null);
+  // Captured once at mount: a restored, already-complete letter shouldn't
+  // re-show the "generating" dialog.
+  const shouldShowGenerationDialog = useRef(letterContent === "");
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasInitialized = useRef(false);
   const LOADING_DISPLAY_DELAY_MS = 1000;
@@ -195,7 +200,9 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
   }, []);
 
   useEffect(() => {
-    dialogRef.current?.showModal();
+    if (shouldShowGenerationDialog.current) {
+      dialogRef.current?.showModal();
+    }
   }, []);
 
   function handleClearMessages() {

--- a/frontend/src/Letter.tsx
+++ b/frontend/src/Letter.tsx
@@ -28,6 +28,7 @@ import FrequentInquiries from "./shared/components/FrequentInquiries";
 import MobilePanel from "./shared/components/MobilePanel";
 import clsx from "clsx";
 import { buildLocationPrefix } from "./shared/utils/buildLocationPrefix";
+import { reloadPage } from "./shared/utils/reloadPage";
 
 /**
  * Routes /letter requests by classifying the leading segment: an out-of-state
@@ -81,12 +82,14 @@ interface LetterViewProps {
 }
 
 function LetterView({ jurisdiction, org }: LetterViewProps) {
-  const { addMessage, messages, setMessages } = useMessages();
+  const { addMessage, messages, setMessages, clearMessages } = useMessages(
+    `letter_messages:${jurisdiction.key},${org ?? ""}`,
+  );
   const isOngoing = messages.length > 0;
   const { letterContent } = useLetterContent(messages);
   const [startStreaming, setStartStreaming] = useState(false);
   const streamLocationRef = useRef<Location | null>(null);
-  const [isGenerating, setIsGenerating] = useState(true);
+  const [isGenerating, setIsGenerating] = useState(letterContent === "");
   const dialogRef = useRef<HTMLDialogElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasInitialized = useRef(false);
@@ -101,27 +104,44 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
     handleCityChange(jurisdiction.key);
   }, [jurisdiction, handleHousingLocation, handleCityChange]);
 
-  // Adds the initial user message once and triggers streaming.
+  // Adds the initial user message once and triggers streaming. Skips
+  // regeneration when a restored session already has a completed letter.
   useEffect(() => {
     if (hasInitialized.current) return;
+    hasInitialized.current = true;
+
+    if (letterContent !== "") {
+      setIsGenerating(false);
+      return;
+    }
+
     const loc = toLocation(jurisdiction);
     const output = buildLetterUserMessage(org, loc);
-    hasInitialized.current = true;
-    const userMessageId = Date.now().toString();
-    const content = [
-      buildLocationPrefix(loc.city, loc.state),
-      issueDescription,
-      output.userMessage,
-    ]
-      .join(" ")
-      .trim();
-    setMessages((prev) => [
-      ...prev,
-      new HumanMessage({ content, id: userMessageId }),
-    ]);
+
+    if (messages.length === 0) {
+      const userMessageId = Date.now().toString();
+      const content = [
+        buildLocationPrefix(loc.city, loc.state),
+        issueDescription,
+        output.userMessage,
+      ]
+        .join(" ")
+        .trim();
+      setMessages((prev) => [
+        ...prev,
+        new HumanMessage({ content, id: userMessageId }),
+      ]);
+    }
     streamLocationRef.current = output.selectedLocation;
     setStartStreaming(true);
-  }, [jurisdiction, org, setMessages, issueDescription]);
+  }, [
+    jurisdiction,
+    org,
+    setMessages,
+    issueDescription,
+    letterContent,
+    messages.length,
+  ]);
 
   useEffect(() => {
     if (startStreaming === false || streamLocationRef.current === null) return;
@@ -178,6 +198,11 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
     dialogRef.current?.showModal();
   }, []);
 
+  function handleClearMessages() {
+    clearMessages();
+    reloadPage();
+  }
+
   return (
     <>
       <LetterGenerationDialog ref={dialogRef} />
@@ -198,10 +223,12 @@ function LetterView({ jurisdiction, org }: LetterViewProps) {
                 </div>
               ) : (
                 <MessageWindow
+                  mode="letter"
                   messages={messages}
                   addMessage={addMessage}
                   setMessages={setMessages}
                   isOngoing={isOngoing}
+                  clearMessages={handleClearMessages}
                 />
               )}
             </div>

--- a/frontend/src/PrivacyPolicy.tsx
+++ b/frontend/src/PrivacyPolicy.tsx
@@ -19,7 +19,7 @@ export default function PrivacyPolicy() {
           <div className="flex flex-col">
             <span>Privacy Policy</span>
             <em className="text-base font-normal">
-              Last Updated: December 7, 2025
+              Last Updated: August 16, 2026
             </em>
           </div>
         }
@@ -59,10 +59,14 @@ export default function PrivacyPolicy() {
         className="space-y-4"
       >
         <p>
-          Tenant First Aid does not store or retain any personal data or
-          conversation transcripts during normal usage. All interactions are
-          processed in real time and are not saved to our servers. We do not
-          encourage you to provide your name, address, or other sensitive
+          Tenant First Aid does not save conversation transcripts to our servers
+          during normal usage. To preserve your conversation when you refresh
+          the page, chat and letter messages are stored temporarily in your
+          browser's session storage. If you identify the device as public,
+          five minutes of inactivity starts a two-minute warning. If the warning
+          expires, Tenant First Aid removes its message history from session
+          storage and closes the page or redirects it to the home page. We do
+          not encourage you to provide your name, address, or other sensitive
           information, and generally do not need it to answer the type of
           general questions that Tenant First Aid is meant for.
         </p>

--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -2,19 +2,35 @@ import { useMutation } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import type { Location } from "../types/models";
 import type { ChatMessage, UiMessage } from "../shared/types/messages";
+import {
+  readSessionStorage,
+  removeSessionStorage,
+  writeSessionStorage,
+} from "../shared/utils/storage";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 
-type StoredMessage = { type: "human" | "ai"; content: string; id: string };
+type StoredMessage = {
+  type: "human" | "ai";
+  content: string;
+  id: string;
+  complete?: boolean;
+};
 
 function loadFromStorage(key: string): ChatMessage[] {
   try {
-    const raw = sessionStorage.getItem(key);
+    const raw = readSessionStorage(key);
     if (!raw) return [];
     const stored: StoredMessage[] = JSON.parse(raw);
     return stored.map((msg) =>
       msg.type === "human"
         ? new HumanMessage({ content: msg.content, id: msg.id })
-        : new AIMessage({ content: msg.content, id: msg.id }),
+        : new AIMessage({
+            content: msg.content,
+            id: msg.id,
+            // Messages stored before completion tracking were only written
+            // after they had content, so preserve them as completed history.
+            additional_kwargs: { complete: msg.complete ?? true },
+          }),
     );
   } catch {
     return [];
@@ -90,18 +106,22 @@ export default function useMessages(storageKey?: string) {
     const toStore: StoredMessage[] = messages
       .filter(
         (msg): msg is Exclude<ChatMessage, UiMessage> =>
-          msg.type !== "ui" && msg.text.trim() !== "" && Boolean(msg.id),
+          msg.type !== "ui" &&
+          msg.text.trim() !== "" &&
+          Boolean(msg.id) &&
+          (msg.type !== "ai" || msg.additional_kwargs.complete === true),
       )
       .map((msg) => ({
-        type: msg instanceof HumanMessage ? "human" : "ai",
+        type: msg.type,
         content: typeof msg.content === "string" ? msg.content : msg.text,
         id: msg.id as string,
+        ...(msg.type === "ai" ? { complete: true } : {}),
       }));
     if (toStore.length === 0) {
-      sessionStorage.removeItem(storageKey);
+      removeSessionStorage(storageKey);
       return;
     }
-    sessionStorage.setItem(storageKey, JSON.stringify(toStore));
+    writeSessionStorage(storageKey, JSON.stringify(toStore));
   }, [messages, storageKey]);
 
   const addMessage = useMutation({
@@ -117,7 +137,7 @@ export default function useMessages(storageKey?: string) {
 
   function clearMessages() {
     if (storageKey) {
-      sessionStorage.removeItem(storageKey);
+      removeSessionStorage(storageKey);
     }
     setMessages([]);
   }

--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -9,6 +9,9 @@ import {
 } from "../shared/utils/storage";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 
+export const CHAT_MESSAGES_STORAGE_PREFIX = "chat_messages:";
+export const LETTER_MESSAGES_STORAGE_PREFIX = "letter_messages:";
+
 type StoredMessage = {
   type: "human" | "ai";
   content: string;
@@ -60,6 +63,7 @@ export function deserializeAiMessage(text: string): string {
 async function addNewMessage(
   messages: ChatMessage[],
   { city, state }: Location,
+  signal: AbortSignal,
 ) {
   const serializedMsg = messages.map((msg) => ({
     role: msg.type,
@@ -71,6 +75,7 @@ async function addNewMessage(
     headers: { "Content-Type": "application/json" },
     credentials: "include",
     body: JSON.stringify({ messages: serializedMsg, city, state }),
+    signal,
   });
   return response.body?.getReader();
 }
@@ -89,13 +94,21 @@ export default function useMessages(storageKey?: string) {
   // from the new key instead of persisting the previous conversation over it.
   const loadedStorageKeyRef = useRef(storageKey);
   const isChangingStorageKeyRef = useRef(false);
+  // Aborts any in-flight request tied to the previous storageKey, so its
+  // stream stops trying to patch a bot message that no longer exists.
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     if (loadedStorageKeyRef.current === storageKey) return;
     loadedStorageKeyRef.current = storageKey;
     isChangingStorageKeyRef.current = true;
+    abortControllerRef.current?.abort();
     setMessages(storageKey ? loadFromStorage(storageKey) : []);
   }, [storageKey]);
+
+  useEffect(() => {
+    return () => abortControllerRef.current?.abort();
+  }, []);
 
   useEffect(() => {
     if (isChangingStorageKeyRef.current) {
@@ -131,7 +144,13 @@ export default function useMessages(storageKey?: string) {
         (msg): msg is Exclude<ChatMessage, UiMessage> =>
           msg.type !== "ui" && msg.text.trim() !== "",
       );
-      return await addNewMessage(filteredMessages, { city, state });
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      return await addNewMessage(
+        filteredMessages,
+        { city, state },
+        controller.signal,
+      );
     },
   });
 

--- a/frontend/src/hooks/useMessages.tsx
+++ b/frontend/src/hooks/useMessages.tsx
@@ -1,7 +1,25 @@
 import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Location } from "../types/models";
 import type { ChatMessage, UiMessage } from "../shared/types/messages";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+
+type StoredMessage = { type: "human" | "ai"; content: string; id: string };
+
+function loadFromStorage(key: string): ChatMessage[] {
+  try {
+    const raw = sessionStorage.getItem(key);
+    if (!raw) return [];
+    const stored: StoredMessage[] = JSON.parse(raw);
+    return stored.map((msg) =>
+      msg.type === "human"
+        ? new HumanMessage({ content: msg.content, id: msg.id })
+        : new AIMessage({ content: msg.content, id: msg.id }),
+    );
+  } catch {
+    return [];
+  }
+}
 
 /**
  * Converts a stored AI message (JSONL chunks) back to plain text for backend
@@ -44,9 +62,47 @@ async function addNewMessage(
 /**
  * Hook for managing chat messages and sending queries to the backend.
  * Provides message state, a setter, and a mutation for posting new messages.
+ * When a storageKey is given, messages persist to sessionStorage so a page
+ * refresh restores the conversation.
  */
-export default function useMessages() {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+export default function useMessages(storageKey?: string) {
+  const [messages, setMessages] = useState<ChatMessage[]>(() =>
+    storageKey ? loadFromStorage(storageKey) : [],
+  );
+  // Track the storageKey a load was applied for, so a change in key reloads
+  // from the new key instead of persisting the previous conversation over it.
+  const loadedStorageKeyRef = useRef(storageKey);
+  const isChangingStorageKeyRef = useRef(false);
+
+  useEffect(() => {
+    if (loadedStorageKeyRef.current === storageKey) return;
+    loadedStorageKeyRef.current = storageKey;
+    isChangingStorageKeyRef.current = true;
+    setMessages(storageKey ? loadFromStorage(storageKey) : []);
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (isChangingStorageKeyRef.current) {
+      isChangingStorageKeyRef.current = false;
+      return;
+    }
+    if (!storageKey) return;
+    const toStore: StoredMessage[] = messages
+      .filter(
+        (msg): msg is Exclude<ChatMessage, UiMessage> =>
+          msg.type !== "ui" && msg.text.trim() !== "" && Boolean(msg.id),
+      )
+      .map((msg) => ({
+        type: msg instanceof HumanMessage ? "human" : "ai",
+        content: typeof msg.content === "string" ? msg.content : msg.text,
+        id: msg.id as string,
+      }));
+    if (toStore.length === 0) {
+      sessionStorage.removeItem(storageKey);
+      return;
+    }
+    sessionStorage.setItem(storageKey, JSON.stringify(toStore));
+  }, [messages, storageKey]);
 
   const addMessage = useMutation({
     mutationFn: async ({ city, state }: Location) => {
@@ -59,9 +115,17 @@ export default function useMessages() {
     },
   });
 
+  function clearMessages() {
+    if (storageKey) {
+      sessionStorage.removeItem(storageKey);
+    }
+    setMessages([]);
+  }
+
   return {
     messages,
     setMessages,
     addMessage: addMessage.mutateAsync,
+    clearMessages,
   };
 }

--- a/frontend/src/pages/Chat/components/MessageWindow.tsx
+++ b/frontend/src/pages/Chat/components/MessageWindow.tsx
@@ -7,16 +7,19 @@ import ExportMessagesButton from "./ExportMessagesButton";
 import InitializationForm from "./InitializationForm";
 import MessageAvatar from "./MessageAvatar";
 import FeedbackModal from "./FeedbackModal";
-import { useLocation } from "react-router-dom";
 import clsx from "clsx";
 
+type MessageWindowMode = "chat" | "letter";
+
 interface Props {
+  mode: MessageWindowMode;
   messages: ChatMessage[];
   addMessage: (
     args: Location,
   ) => Promise<ReadableStreamDefaultReader<Uint8Array> | undefined>;
   setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
   isOngoing: boolean;
+  clearMessages: () => void;
 }
 
 /**
@@ -24,27 +27,27 @@ interface Props {
  * Shows the initialization form when no messages exist.
  */
 export default function MessageWindow({
+  mode,
   messages,
   addMessage,
   setMessages,
   isOngoing,
+  clearMessages,
 }: Props) {
   const [isLoading, setIsLoading] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [openFeedback, setOpenFeedback] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const messagesRef = useRef<HTMLDivElement | null>(null);
-  const loc = useLocation();
 
   // Hides the initial user prompt and AI letter response on the letter page
   // (index 0 = user prompt, index 1 = AI letter generation).
   const LETTER_PAGE_HIDDEN_MESSAGES = 2;
-  const displayedMessages = loc.pathname.startsWith("/letter")
-    ? messages.slice(LETTER_PAGE_HIDDEN_MESSAGES)
-    : messages;
+  const displayedMessages =
+    mode === "letter" ? messages.slice(LETTER_PAGE_HIDDEN_MESSAGES) : messages;
 
   const handleClearSession = () => {
-    window.location.reload();
+    clearMessages();
   };
 
   useEffect(() => {
@@ -144,12 +147,12 @@ export default function MessageWindow({
               </button>
             </div>
           </>
-        ) : (
+        ) : mode === "chat" ? (
           <InitializationForm
             addMessage={addMessage}
             setMessages={setMessages}
           />
-        )}
+        ) : null}
       </div>
     </>
   );

--- a/frontend/src/pages/Chat/components/MessageWindow.tsx
+++ b/frontend/src/pages/Chat/components/MessageWindow.tsx
@@ -8,6 +8,7 @@ import InitializationForm from "./InitializationForm";
 import MessageAvatar from "./MessageAvatar";
 import FeedbackModal from "./FeedbackModal";
 import clsx from "clsx";
+import useHousingContext from "../../../hooks/useHousingContext";
 
 type MessageWindowMode = "chat" | "letter";
 
@@ -39,6 +40,7 @@ export default function MessageWindow({
   const [openFeedback, setOpenFeedback] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const messagesRef = useRef<HTMLDivElement | null>(null);
+  const { handleFormReset } = useHousingContext();
 
   // Hides the initial user prompt and AI letter response on the letter page
   // (index 0 = user prompt, index 1 = AI letter generation).
@@ -47,6 +49,7 @@ export default function MessageWindow({
     mode === "letter" ? messages.slice(LETTER_PAGE_HIDDEN_MESSAGES) : messages;
 
   const handleClearSession = () => {
+    handleFormReset();
     clearMessages();
   };
 

--- a/frontend/src/pages/Chat/utils/streamHelper.ts
+++ b/frontend/src/pages/Chat/utils/streamHelper.ts
@@ -118,6 +118,12 @@ async function streamText({
       processLines(lines);
     }
   } catch (error) {
+    // The request was intentionally cancelled (e.g. jurisdiction changed
+    // mid-stream) — the message list has already moved on, so don't patch
+    // it with an error meant for a conversation that's no longer showing.
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return;
+    }
     console.error("Error:", error);
     const errorMessage: UiMessage = {
       type: "ui",

--- a/frontend/src/pages/Chat/utils/streamHelper.ts
+++ b/frontend/src/pages/Chat/utils/streamHelper.ts
@@ -36,7 +36,11 @@ async function streamText({
   // Add empty bot message immediately so "Typing..." appears before the API responds.
   setMessages((prev) => [
     ...prev,
-    new AIMessage({ content: "", id: botMessageId }),
+    new AIMessage({
+      content: "",
+      id: botMessageId,
+      additional_kwargs: { complete: false },
+    }),
   ]);
 
   try {
@@ -66,6 +70,17 @@ async function streamText({
             const parsed = JSON.parse(processedText) as { type?: string };
             if (parsed.type === "end_of_stream") {
               receivedDone = true;
+              setMessages((prev) =>
+                prev.map((msg) =>
+                  msg.id === botMessageId && msg.type === "ai"
+                    ? new AIMessage({
+                        content: msg.content,
+                        id: botMessageId,
+                        additional_kwargs: { complete: true },
+                      })
+                    : msg,
+                ),
+              );
               onDone?.();
               return;
             }
@@ -76,6 +91,7 @@ async function streamText({
           const botMessage = new AIMessage({
             content: fullText,
             id: botMessageId,
+            additional_kwargs: { complete: false },
           });
           setMessages((prev) =>
             prev.map((msg) => (msg.id === botMessageId ? botMessage : msg)),

--- a/frontend/src/shared/components/DevicePrivacyGuard.tsx
+++ b/frontend/src/shared/components/DevicePrivacyGuard.tsx
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { readSessionStorage, writeSessionStorage } from "../utils/storage";
+
+export const DEVICE_PRIVACY_STORAGE_KEY = "device_privacy";
+export const PUBLIC_DEVICE_IDLE_MS = 5 * 60 * 1000;
+export const SHUTDOWN_SECONDS = 120;
+
+type DevicePrivacy = "private" | "public";
+
+function readDevicePrivacy(): DevicePrivacy | null {
+  const stored = readSessionStorage(DEVICE_PRIVACY_STORAGE_KEY);
+  return stored === "private" || stored === "public" ? stored : null;
+}
+
+interface Props {
+  children: React.ReactNode;
+}
+
+/**
+ * Requires a device privacy choice before rendering sensitive pages and, on a
+ * public device, clears the session after an inactivity warning expires.
+ */
+export default function DevicePrivacyGuard({ children }: Props) {
+  const [devicePrivacy, setDevicePrivacy] =
+    useState<DevicePrivacy | null>(readDevicePrivacy);
+  const [shutdownDeadline, setShutdownDeadline] = useState<number | null>(null);
+  const [secondsRemaining, setSecondsRemaining] = useState(SHUTDOWN_SECONDS);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearIdleTimer = useCallback(() => {
+    if (idleTimerRef.current !== null) {
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = null;
+    }
+  }, []);
+
+  const resetIdleTimer = useCallback(() => {
+    if (devicePrivacy !== "public" || shutdownDeadline !== null) return;
+    clearIdleTimer();
+    idleTimerRef.current = setTimeout(() => {
+      setShutdownDeadline(Date.now() + SHUTDOWN_SECONDS * 1000);
+      setSecondsRemaining(SHUTDOWN_SECONDS);
+    }, PUBLIC_DEVICE_IDLE_MS);
+  }, [clearIdleTimer, devicePrivacy, shutdownDeadline]);
+
+  useEffect(() => {
+    if (devicePrivacy !== "public" || shutdownDeadline !== null) {
+      clearIdleTimer();
+      return;
+    }
+
+    const activityEvents: (keyof WindowEventMap)[] = [
+      "click",
+      "keydown",
+      "mousemove",
+      "scroll",
+      "touchstart",
+    ];
+    activityEvents.forEach((event) =>
+      window.addEventListener(event, resetIdleTimer, { passive: true }),
+    );
+    resetIdleTimer();
+
+    return () => {
+      activityEvents.forEach((event) =>
+        window.removeEventListener(event, resetIdleTimer),
+      );
+      clearIdleTimer();
+    };
+  }, [clearIdleTimer, devicePrivacy, resetIdleTimer, shutdownDeadline]);
+
+  useEffect(() => {
+    if (shutdownDeadline === null) return;
+
+    const updateCountdown = () => {
+      const remaining = Math.max(
+        0,
+        Math.ceil((shutdownDeadline - Date.now()) / 1000),
+      );
+      setSecondsRemaining(remaining);
+
+      if (remaining === 0) {
+        window.clearInterval(countdownTimer);
+        sessionStorage.clear();
+        window.close();
+        // Browsers only permit scripts to close tabs that scripts opened.
+        // Redirect away from sensitive content when closing is blocked.
+        window.location.replace("/");
+      }
+    };
+
+    const countdownTimer = window.setInterval(updateCountdown, 250);
+    updateCountdown();
+    return () => window.clearInterval(countdownTimer);
+  }, [shutdownDeadline]);
+
+  function selectDevice(value: DevicePrivacy) {
+    writeSessionStorage(DEVICE_PRIVACY_STORAGE_KEY, value);
+    setDevicePrivacy(value);
+  }
+
+  function cancelShutdown() {
+    setShutdownDeadline(null);
+    setSecondsRemaining(SHUTDOWN_SECONDS);
+  }
+
+  if (devicePrivacy === null) {
+    return (
+      <Modal title="Is this a public or private device?">
+        <p className="mb-5 text-gray-dark">
+          Choose public if other people can access this device. We will use
+          your answer to help protect your conversation history.
+        </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={() => selectDevice("public")}
+            className="border border-green-dark text-green-dark hover:bg-green-light"
+          >
+            Public device
+          </button>
+          <button
+            type="button"
+            onClick={() => selectDevice("private")}
+            className="bg-green-dark text-white hover:bg-green-medium"
+          >
+            Private device
+          </button>
+        </div>
+      </Modal>
+    );
+  }
+
+  return (
+    <>
+      <div className="contents" inert={shutdownDeadline !== null}>
+        {children}
+      </div>
+      {shutdownDeadline !== null && (
+        <Modal title="Are you still there?">
+          <p className="mb-5 text-gray-dark" aria-live="polite">
+            If you do nothing, this page will close in {secondsRemaining}{" "}
+            {secondsRemaining === 1 ? "second" : "seconds"}, clearing all
+            message history.
+          </p>
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={cancelShutdown}
+              className="bg-green-dark text-white hover:bg-green-medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+interface ModalProps {
+  children: React.ReactNode;
+  title: string;
+}
+
+function Modal({ children, title }: ModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="device-privacy-dialog-title"
+    >
+      <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+        <h2 id="device-privacy-dialog-title" className="mb-3 text-xl font-bold">
+          {title}
+        </h2>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shared/components/DevicePrivacyGuard.tsx
+++ b/frontend/src/shared/components/DevicePrivacyGuard.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import {
-  clearSessionStorage,
   readSessionStorage,
+  removeSessionStorage,
+  removeSessionStorageByPrefix,
   writeSessionStorage,
 } from "../utils/storage";
+import {
+  CHAT_MESSAGES_STORAGE_PREFIX,
+  LETTER_MESSAGES_STORAGE_PREFIX,
+} from "../../hooks/useMessages";
 
 export const DEVICE_PRIVACY_STORAGE_KEY = "device_privacy";
 export const PUBLIC_DEVICE_IDLE_MS = 5 * 60 * 1000;
@@ -15,6 +20,16 @@ type DevicePrivacy = "private" | "public";
 function readDevicePrivacy(): DevicePrivacy | null {
   const stored = readSessionStorage(DEVICE_PRIVACY_STORAGE_KEY);
   return stored === "private" || stored === "public" ? stored : null;
+}
+
+/**
+ * Removes the sessionStorage keys this app is known to write, rather than
+ * clearing all of sessionStorage, so unrelated data isn't touched.
+ */
+function clearKnownSessionStorage() {
+  removeSessionStorage(DEVICE_PRIVACY_STORAGE_KEY);
+  removeSessionStorageByPrefix(CHAT_MESSAGES_STORAGE_PREFIX);
+  removeSessionStorageByPrefix(LETTER_MESSAGES_STORAGE_PREFIX);
 }
 
 interface Props {
@@ -79,7 +94,7 @@ export default function DevicePrivacyGuard({ children }: Props) {
 
       if (remaining === 0) {
         window.clearInterval(countdownTimer);
-        clearSessionStorage();
+        clearKnownSessionStorage();
         window.close();
         // Browsers only permit scripts to close tabs that scripts opened.
         // Redirect away from sensitive content when closing is blocked.
@@ -104,7 +119,7 @@ export default function DevicePrivacyGuard({ children }: Props) {
 
   if (devicePrivacy === null) {
     return (
-      <Modal title="Is this a public or private device?">
+      <Modal title="Is this a public or private device?" dismissible={false}>
         <p className="mb-5 text-gray-dark">
           Choose public if other people can access this device. We will use your
           answer to help protect your conversation history.
@@ -135,7 +150,7 @@ export default function DevicePrivacyGuard({ children }: Props) {
         {children}
       </div>
       {shutdownDeadline !== null && (
-        <Modal title="Are you still there?">
+        <Modal title="Are you still there?" onClose={cancelShutdown}>
           <p className="mb-5 text-gray-dark" aria-live="polite">
             If you do nothing, this page will close in {secondsRemaining}{" "}
             {secondsRemaining === 1 ? "second" : "seconds"}, clearing all
@@ -159,22 +174,33 @@ export default function DevicePrivacyGuard({ children }: Props) {
 interface ModalProps {
   children: React.ReactNode;
   title: string;
+  /** When false, Escape cannot dismiss the dialog; only an explicit choice can. */
+  dismissible?: boolean;
+  onClose?: () => void;
 }
 
-function Modal({ children, title }: ModalProps) {
+
+function Modal({ children, title, dismissible = true, onClose }: ModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    dialogRef.current?.showModal();
+  }, []);
+
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={dialogRef}
+      onCancel={(event) => {
+        if (!dismissible) event.preventDefault();
+      }}
+      onClose={onClose}
       aria-labelledby="device-privacy-dialog-title"
+      className="fixed top-1/2 left-1/2 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg border-none bg-white p-6 shadow-xl backdrop:bg-black/50"
     >
-      <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
-        <h2 id="device-privacy-dialog-title" className="mb-3 text-xl font-bold">
-          {title}
-        </h2>
-        {children}
-      </div>
-    </div>
+      <h2 id="device-privacy-dialog-title" className="mb-3 text-xl font-bold">
+        {title}
+      </h2>
+      {children}
+    </dialog>
   );
 }

--- a/frontend/src/shared/components/DevicePrivacyGuard.tsx
+++ b/frontend/src/shared/components/DevicePrivacyGuard.tsx
@@ -1,9 +1,14 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { readSessionStorage, writeSessionStorage } from "../utils/storage";
+import { useEffect, useRef, useState } from "react";
+import {
+  clearSessionStorage,
+  readSessionStorage,
+  writeSessionStorage,
+} from "../utils/storage";
 
 export const DEVICE_PRIVACY_STORAGE_KEY = "device_privacy";
 export const PUBLIC_DEVICE_IDLE_MS = 5 * 60 * 1000;
 export const SHUTDOWN_SECONDS = 120;
+const IDLE_CHECK_INTERVAL_MS = 1000;
 
 type DevicePrivacy = "private" | "public";
 
@@ -21,33 +26,19 @@ interface Props {
  * public device, clears the session after an inactivity warning expires.
  */
 export default function DevicePrivacyGuard({ children }: Props) {
-  const [devicePrivacy, setDevicePrivacy] =
-    useState<DevicePrivacy | null>(readDevicePrivacy);
+  const [devicePrivacy, setDevicePrivacy] = useState<DevicePrivacy | null>(
+    readDevicePrivacy,
+  );
   const [shutdownDeadline, setShutdownDeadline] = useState<number | null>(null);
   const [secondsRemaining, setSecondsRemaining] = useState(SHUTDOWN_SECONDS);
-  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const clearIdleTimer = useCallback(() => {
-    if (idleTimerRef.current !== null) {
-      clearTimeout(idleTimerRef.current);
-      idleTimerRef.current = null;
-    }
-  }, []);
-
-  const resetIdleTimer = useCallback(() => {
-    if (devicePrivacy !== "public" || shutdownDeadline !== null) return;
-    clearIdleTimer();
-    idleTimerRef.current = setTimeout(() => {
-      setShutdownDeadline(Date.now() + SHUTDOWN_SECONDS * 1000);
-      setSecondsRemaining(SHUTDOWN_SECONDS);
-    }, PUBLIC_DEVICE_IDLE_MS);
-  }, [clearIdleTimer, devicePrivacy, shutdownDeadline]);
+  const lastActivityRef = useRef(Date.now());
 
   useEffect(() => {
-    if (devicePrivacy !== "public" || shutdownDeadline !== null) {
-      clearIdleTimer();
-      return;
-    }
+    if (devicePrivacy !== "public" || shutdownDeadline !== null) return;
+
+    const recordActivity = () => {
+      lastActivityRef.current = Date.now();
+    };
 
     const activityEvents: (keyof WindowEventMap)[] = [
       "click",
@@ -57,17 +48,24 @@ export default function DevicePrivacyGuard({ children }: Props) {
       "touchstart",
     ];
     activityEvents.forEach((event) =>
-      window.addEventListener(event, resetIdleTimer, { passive: true }),
+      window.addEventListener(event, recordActivity, { passive: true }),
     );
-    resetIdleTimer();
+    recordActivity();
+
+    const idleCheckTimer = window.setInterval(() => {
+      if (Date.now() - lastActivityRef.current >= PUBLIC_DEVICE_IDLE_MS) {
+        setShutdownDeadline(Date.now() + SHUTDOWN_SECONDS * 1000);
+        setSecondsRemaining(SHUTDOWN_SECONDS);
+      }
+    }, IDLE_CHECK_INTERVAL_MS);
 
     return () => {
       activityEvents.forEach((event) =>
-        window.removeEventListener(event, resetIdleTimer),
+        window.removeEventListener(event, recordActivity),
       );
-      clearIdleTimer();
+      window.clearInterval(idleCheckTimer);
     };
-  }, [clearIdleTimer, devicePrivacy, resetIdleTimer, shutdownDeadline]);
+  }, [devicePrivacy, shutdownDeadline]);
 
   useEffect(() => {
     if (shutdownDeadline === null) return;
@@ -81,7 +79,7 @@ export default function DevicePrivacyGuard({ children }: Props) {
 
       if (remaining === 0) {
         window.clearInterval(countdownTimer);
-        sessionStorage.clear();
+        clearSessionStorage();
         window.close();
         // Browsers only permit scripts to close tabs that scripts opened.
         // Redirect away from sensitive content when closing is blocked.
@@ -108,8 +106,8 @@ export default function DevicePrivacyGuard({ children }: Props) {
     return (
       <Modal title="Is this a public or private device?">
         <p className="mb-5 text-gray-dark">
-          Choose public if other people can access this device. We will use
-          your answer to help protect your conversation history.
+          Choose public if other people can access this device. We will use your
+          answer to help protect your conversation history.
         </p>
         <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
           <button

--- a/frontend/src/shared/utils/reloadPage.ts
+++ b/frontend/src/shared/utils/reloadPage.ts
@@ -1,0 +1,3 @@
+export function reloadPage() {
+  window.location.reload();
+}

--- a/frontend/src/shared/utils/storage.ts
+++ b/frontend/src/shared/utils/storage.ts
@@ -59,12 +59,17 @@ export function removeSessionStorage(key: string): void {
 }
 
 /**
- * Clears all sessionStorage as best-effort persistence.
- * Storage failures are ignored.
+ * Removes every sessionStorage key starting with the given prefix, as
+ * best-effort persistence. Storage failures are ignored.
  */
-export function clearSessionStorage(): void {
+export function removeSessionStorageByPrefix(prefix: string): void {
   try {
-    sessionStorage.clear();
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const key = sessionStorage.key(i);
+      if (key?.startsWith(prefix)) keysToRemove.push(key);
+    }
+    keysToRemove.forEach((key) => sessionStorage.removeItem(key));
   } catch {
     // Ignored: callers treat persistence as best-effort.
   }

--- a/frontend/src/shared/utils/storage.ts
+++ b/frontend/src/shared/utils/storage.ts
@@ -45,3 +45,27 @@ export function writeSessionStorage(key: string, value: string): void {
     // Ignored: callers treat persistence as best-effort.
   }
 }
+
+/**
+ * Removes a sessionStorage value as best-effort persistence.
+ * Storage failures are ignored.
+ */
+export function removeSessionStorage(key: string): void {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    // Ignored: callers treat persistence as best-effort.
+  }
+}
+
+/**
+ * Clears all sessionStorage as best-effort persistence.
+ * Storage failures are ignored.
+ */
+export function clearSessionStorage(): void {
+  try {
+    sessionStorage.clear();
+  } catch {
+    // Ignored: callers treat persistence as best-effort.
+  }
+}

--- a/frontend/src/shared/utils/storage.ts
+++ b/frontend/src/shared/utils/storage.ts
@@ -21,3 +21,27 @@ export function writeStorage(key: string, value: string): void {
     // Ignored: callers treat persistence as best-effort.
   }
 }
+
+/**
+ * Reads a sessionStorage value, returning null when the key is absent or when
+ * storage access throws (e.g. blocked site data).
+ */
+export function readSessionStorage(key: string): string | null {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Writes a sessionStorage value as best-effort persistence.
+ * Storage failures are ignored.
+ */
+export function writeSessionStorage(key: string, value: string): void {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {
+    // Ignored: callers treat persistence as best-effort.
+  }
+}

--- a/frontend/src/tests/components/Chat.test.tsx
+++ b/frontend/src/tests/components/Chat.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../hooks/useMessages", () => ({
     setMessages: vi.fn(),
     addMessage: vi.fn(),
   }),
+  CHAT_MESSAGES_STORAGE_PREFIX: "chat_messages:",
 }));
 
 vi.mock("../../pages/Chat/components/MessageWindow", () => ({

--- a/frontend/src/tests/components/DevicePrivacyGuard.test.tsx
+++ b/frontend/src/tests/components/DevicePrivacyGuard.test.tsx
@@ -1,0 +1,69 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DevicePrivacyGuard, {
+  DEVICE_PRIVACY_STORAGE_KEY,
+  PUBLIC_DEVICE_IDLE_MS,
+  SHUTDOWN_SECONDS,
+} from "../../shared/components/DevicePrivacyGuard";
+
+describe("DevicePrivacyGuard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stores the initial private-device choice and displays the page", () => {
+    render(
+      <DevicePrivacyGuard>
+        <div>Sensitive page</div>
+      </DevicePrivacyGuard>,
+    );
+
+    expect(screen.queryByText("Sensitive page")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Private device" }));
+
+    expect(sessionStorage.getItem(DEVICE_PRIVACY_STORAGE_KEY)).toBe("private");
+    expect(screen.getByText("Sensitive page")).toBeInTheDocument();
+  });
+
+  it("warns after five idle minutes and cancel restarts inactivity tracking", () => {
+    vi.useFakeTimers();
+    sessionStorage.setItem(DEVICE_PRIVACY_STORAGE_KEY, "public");
+    render(
+      <DevicePrivacyGuard>
+        <div>Sensitive page</div>
+      </DevicePrivacyGuard>,
+    );
+
+    act(() => vi.advanceTimersByTime(PUBLIC_DEVICE_IDLE_MS));
+    expect(screen.getByRole("dialog")).toHaveTextContent(
+      `close in ${SHUTDOWN_SECONDS} seconds`,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(PUBLIC_DEVICE_IDLE_MS));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("resets the public-device inactivity timer when the user is active", () => {
+    vi.useFakeTimers();
+    sessionStorage.setItem(DEVICE_PRIVACY_STORAGE_KEY, "public");
+    render(
+      <DevicePrivacyGuard>
+        <div>Sensitive page</div>
+      </DevicePrivacyGuard>,
+    );
+
+    act(() => vi.advanceTimersByTime(PUBLIC_DEVICE_IDLE_MS - 1000));
+    fireEvent.keyDown(window, { key: "Tab" });
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/DevicePrivacyGuard.test.tsx
+++ b/frontend/src/tests/components/DevicePrivacyGuard.test.tsx
@@ -1,5 +1,13 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import DevicePrivacyGuard, {
   DEVICE_PRIVACY_STORAGE_KEY,
   PUBLIC_DEVICE_IDLE_MS,
@@ -7,6 +15,20 @@ import DevicePrivacyGuard, {
 } from "../../shared/components/DevicePrivacyGuard";
 
 describe("DevicePrivacyGuard", () => {
+  beforeAll(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (
+      this: HTMLDialogElement,
+    ) {
+      this.setAttribute("open", "");
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (
+      this: HTMLDialogElement,
+    ) {
+      this.removeAttribute("open");
+      this.dispatchEvent(new Event("close"));
+    });
+  });
+
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
@@ -65,5 +87,28 @@ describe("DevicePrivacyGuard", () => {
     act(() => vi.advanceTimersByTime(1000));
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("removes message history and closes the page when the warning expires", () => {
+    vi.useFakeTimers();
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+    sessionStorage.setItem(DEVICE_PRIVACY_STORAGE_KEY, "public");
+    sessionStorage.setItem("chat_messages:portland", "chat history");
+    sessionStorage.setItem("letter_messages:portland", "letter history");
+    sessionStorage.setItem("unrelated", "keep me");
+    render(
+      <DevicePrivacyGuard>
+        <div>Sensitive page</div>
+      </DevicePrivacyGuard>,
+    );
+
+    act(() => vi.advanceTimersByTime(PUBLIC_DEVICE_IDLE_MS));
+    act(() => vi.advanceTimersByTime(SHUTDOWN_SECONDS * 1000));
+
+    expect(sessionStorage.getItem(DEVICE_PRIVACY_STORAGE_KEY)).toBeNull();
+    expect(sessionStorage.getItem("chat_messages:portland")).toBeNull();
+    expect(sessionStorage.getItem("letter_messages:portland")).toBeNull();
+    expect(sessionStorage.getItem("unrelated")).toBe("keep me");
+    expect(closeSpy).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/tests/components/Letter.test.tsx
+++ b/frontend/src/tests/components/Letter.test.tsx
@@ -35,6 +35,7 @@ vi.mock("../../pages/Chat/utils/streamHelper", () => ({
 
 vi.mock("../../hooks/useMessages", () => ({
   default: vi.fn(),
+  LETTER_MESSAGES_STORAGE_PREFIX: "letter_messages:",
 }));
 
 vi.mock("../../hooks/useLetterContent", () => ({

--- a/frontend/src/tests/components/Letter.test.tsx
+++ b/frontend/src/tests/components/Letter.test.tsx
@@ -16,7 +16,7 @@ import {
 } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
-import { HumanMessage } from "@langchain/core/messages";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import type { ChatMessage } from "../../shared/types/messages";
 
 beforeAll(() => {
@@ -38,11 +38,19 @@ vi.mock("../../hooks/useMessages", () => ({
 }));
 
 vi.mock("../../hooks/useLetterContent", () => ({
-  useLetterContent: () => ({ letterContent: "" }),
+  useLetterContent: vi.fn(),
 }));
 
 vi.mock("../../pages/Chat/components/MessageWindow", () => ({
-  default: () => <div data-testid="message-window" />,
+  default: ({ clearMessages }: { clearMessages: () => void }) => (
+    <div data-testid="message-window">
+      <button onClick={clearMessages}>Clear Letter</button>
+    </div>
+  ),
+}));
+
+vi.mock("../../shared/utils/reloadPage", () => ({
+  reloadPage: vi.fn(),
 }));
 
 vi.mock("../../LetterGenerationDialog", () => ({
@@ -56,10 +64,14 @@ vi.mock("../../LetterGenerationDialog", () => ({
 
 import * as streamHelper from "../../pages/Chat/utils/streamHelper";
 import useMessages from "../../hooks/useMessages";
+import { useLetterContent } from "../../hooks/useLetterContent";
+import { reloadPage } from "../../shared/utils/reloadPage";
 import HousingContextProvider from "../../contexts/HousingContext";
 
 let mockStreamText: ReturnType<typeof vi.fn>;
 let mockUseMessages: ReturnType<typeof vi.fn>;
+let mockUseLetterContent: ReturnType<typeof vi.fn>;
+let mockReloadPage: ReturnType<typeof vi.fn>;
 
 const renderLetter = async (initialEntry = "/letter/or/portland?org=org") => {
   const { default: Letter } = await import("../../Letter");
@@ -81,14 +93,18 @@ describe("Letter component - effect orchestration", () => {
   beforeEach(() => {
     mockStreamText = vi.mocked(streamHelper.streamText);
     mockUseMessages = vi.mocked(useMessages);
+    mockUseLetterContent = vi.mocked(useLetterContent);
+    mockReloadPage = vi.mocked(reloadPage);
 
     mockStreamText.mockClear();
     mockStreamText.mockResolvedValue(undefined);
+    mockUseLetterContent.mockReturnValue({ letterContent: "" });
 
     mockUseMessages.mockReturnValue({
       addMessage: vi.fn(),
       messages: [],
       setMessages: vi.fn(),
+      clearMessages: vi.fn(),
     });
   });
 
@@ -112,6 +128,7 @@ describe("Letter component - effect orchestration", () => {
       addMessage: mockAddMessage,
       messages: [],
       setMessages: mockSetMessages,
+      clearMessages: vi.fn(),
     });
 
     await renderLetter();
@@ -142,12 +159,102 @@ describe("Letter component - effect orchestration", () => {
       addMessage: mockAddMessage,
       messages: [new HumanMessage({ content: "hi", id: "1" })],
       setMessages: mockSetMessages,
+      clearMessages: vi.fn(),
     });
 
     await renderLetter();
     await waitFor(() => {
       expect(screen.queryByText("Generating Letter...")).not.toBeNull();
     });
+  });
+
+  it("restores a completed letter without generating it again", async () => {
+    const mockSetMessages = vi.fn();
+    mockUseMessages.mockReturnValue({
+      addMessage: vi.fn(),
+      messages: [
+        new HumanMessage({ content: "Generate my letter", id: "1" }),
+        new AIMessage({
+          content: '{"type":"letter","content":"Dear Landlord,"}\n',
+          id: "2",
+        }),
+      ],
+      setMessages: mockSetMessages,
+      clearMessages: vi.fn(),
+    });
+    mockUseLetterContent.mockReturnValue({
+      letterContent: "Dear Landlord,",
+    });
+
+    await renderLetter();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("message-window")).not.toBeNull();
+    });
+
+    expect(screen.queryByText("Generating Letter...")).toBeNull();
+    expect(mockSetMessages).not.toHaveBeenCalled();
+    expect(mockStreamText).not.toHaveBeenCalled();
+  });
+
+  it("retries an incomplete restored session without duplicating the prompt", async () => {
+    const mockSetMessages = vi.fn();
+    const restoredPrompt = new HumanMessage({
+      content: "Generate my letter",
+      id: "1",
+    });
+    mockUseMessages.mockReturnValue({
+      addMessage: vi.fn(),
+      messages: [restoredPrompt],
+      setMessages: mockSetMessages,
+      clearMessages: vi.fn(),
+    });
+
+    await renderLetter();
+
+    await waitFor(() => {
+      expect(mockStreamText).toHaveBeenCalled();
+    });
+
+    const duplicatedPrompt = mockSetMessages.mock.calls.some((call) => {
+      const update = call[0];
+      if (typeof update !== "function") return false;
+      const updatedMessages = update([restoredPrompt]) as ChatMessage[];
+      return (
+        updatedMessages.filter((message) => message.type === "human").length > 1
+      );
+    });
+    expect(duplicatedPrompt).toBe(false);
+  });
+
+  it("clears the letter before reloading the page", async () => {
+    const callOrder: string[] = [];
+    const mockClearMessages = vi.fn(() => {
+      callOrder.push("clear");
+    });
+    mockReloadPage.mockImplementation(() => {
+      callOrder.push("reload");
+    });
+    mockUseMessages.mockReturnValue({
+      addMessage: vi.fn(),
+      messages: [
+        new HumanMessage({ content: "Generate my letter", id: "1" }),
+        new AIMessage({
+          content: '{"type":"letter","content":"Dear Landlord,"}\n',
+          id: "2",
+        }),
+      ],
+      setMessages: vi.fn(),
+      clearMessages: mockClearMessages,
+    });
+    mockUseLetterContent.mockReturnValue({
+      letterContent: "Dear Landlord,",
+    });
+
+    await renderLetter();
+    fireEvent.click(screen.getByText("Clear Letter"));
+
+    expect(callOrder).toEqual(["clear", "reload"]);
   });
 
   it("dialog closes when close button clicked", async () => {
@@ -206,6 +313,7 @@ describe("Letter component - effect orchestration", () => {
       addMessage: vi.fn(),
       messages: [],
       setMessages: mockSetMessages,
+      clearMessages: vi.fn(),
     });
 
     await renderLetter();

--- a/frontend/src/tests/components/MessageWindow.test.tsx
+++ b/frontend/src/tests/components/MessageWindow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import MessageWindow from "../../pages/Chat/components/MessageWindow";
@@ -25,10 +25,12 @@ describe("MessageWindow component", () => {
   ];
 
   const defaultProps = {
+    mode: "chat" as const,
     messages,
     addMessage: vi.fn(),
     setMessages: vi.fn(),
     isOngoing: true,
+    clearMessages: vi.fn(),
   };
 
   it("hides first 2 messages on letter page", () => {
@@ -37,7 +39,7 @@ describe("MessageWindow component", () => {
       <QueryClientProvider client={queryClient}>
         <HousingContextProvider>
           <MemoryRouter initialEntries={["/letter/some-org"]}>
-            <MessageWindow {...defaultProps} />
+            <MessageWindow {...defaultProps} mode="letter" />
           </MemoryRouter>
         </HousingContextProvider>
       </QueryClientProvider>,
@@ -63,5 +65,60 @@ describe("MessageWindow component", () => {
     expect(screen.getByText("first message")).toBeInTheDocument();
     expect(screen.getByText("second message")).toBeInTheDocument();
     expect(screen.getByText("third message")).toBeInTheDocument();
+  });
+
+  it("does not show the chat initialization form for an empty letter", () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HousingContextProvider>
+          <MemoryRouter initialEntries={["/letter/or/portland"]}>
+            <MessageWindow
+              {...defaultProps}
+              mode="letter"
+              messages={[]}
+              isOngoing={false}
+            />
+          </MemoryRouter>
+        </HousingContextProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByText("Welcome to Tenant First Aid!")).toBeNull();
+  });
+
+  it("shows the chat initialization form for an empty chat", () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HousingContextProvider>
+          <MemoryRouter initialEntries={["/chat/or/portland"]}>
+            <MessageWindow {...defaultProps} messages={[]} isOngoing={false} />
+          </MemoryRouter>
+        </HousingContextProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.getByText("Welcome to Tenant First Aid!"),
+    ).toBeInTheDocument();
+  });
+
+  it("delegates clearing to the provided callback", () => {
+    const clearMessages = vi.fn();
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HousingContextProvider>
+          <MemoryRouter initialEntries={["/chat/or/portland"]}>
+            <MessageWindow {...defaultProps} clearMessages={clearMessages} />
+          </MemoryRouter>
+        </HousingContextProvider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "clear chat" }));
+
+    expect(clearMessages).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/tests/components/MessageWindow.test.tsx
+++ b/frontend/src/tests/components/MessageWindow.test.tsx
@@ -5,6 +5,19 @@ import MessageWindow from "../../pages/Chat/components/MessageWindow";
 import type { ChatMessage } from "../../shared/types/messages";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import HousingContextProvider from "../../contexts/HousingContext";
+import useHousingContext from "../../hooks/useHousingContext";
+
+function IssueDescriptionProbe() {
+  const { issueDescription, handleIssueDescription } = useHousingContext();
+
+  return (
+    <textarea
+      data-testid="issue-description-probe"
+      value={issueDescription}
+      onChange={handleIssueDescription}
+    />
+  );
+}
 
 beforeAll(() => {
   if (!("scrollTo" in HTMLElement.prototype)) {
@@ -120,5 +133,29 @@ describe("MessageWindow component", () => {
     fireEvent.click(screen.getByRole("button", { name: "clear chat" }));
 
     expect(clearMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the issue description when clearing the chat", () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HousingContextProvider>
+          <MemoryRouter initialEntries={["/chat/or/portland"]}>
+            <IssueDescriptionProbe />
+            <MessageWindow {...defaultProps} />
+          </MemoryRouter>
+        </HousingContextProvider>
+      </QueryClientProvider>,
+    );
+
+    const issueDescription = screen.getByTestId("issue-description-probe");
+    fireEvent.change(issueDescription, {
+      target: { value: "My previous housing issue" },
+    });
+    expect(issueDescription).toHaveValue("My previous housing issue");
+
+    fireEvent.click(screen.getByRole("button", { name: "clear chat" }));
+
+    expect(issueDescription).toHaveValue("");
   });
 });

--- a/frontend/src/tests/hooks/useMessages.test.ts
+++ b/frontend/src/tests/hooks/useMessages.test.ts
@@ -60,6 +60,16 @@ describe("useMessages", () => {
     expect(result.current.messages).toEqual([]);
   });
 
+  it("starts with empty messages when sessionStorage reads are blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("Access denied", "SecurityError");
+    });
+
+    expect(() =>
+      renderHook(() => useMessages("test_key"), { wrapper }),
+    ).not.toThrow();
+  });
+
   it("loads messages from sessionStorage on init", () => {
     const stored = [
       { type: "human", content: "hello", id: "1" },
@@ -84,6 +94,59 @@ describe("useMessages", () => {
 
     const stored = JSON.parse(sessionStorage.getItem("test_key") ?? "[]");
     expect(stored).toEqual([{ type: "human", content: "hi", id: "1" }]);
+  });
+
+  it("keeps working when sessionStorage quota is exceeded", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Quota exceeded", "QuotaExceededError");
+    });
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+
+    expect(() => {
+      act(() => {
+        result.current.setMessages([
+          new HumanMessage({ content: "hi", id: "1" }),
+        ]);
+      });
+    }).not.toThrow();
+    expect(result.current.messages).toHaveLength(1);
+  });
+
+  it("does not persist an incomplete AI message", () => {
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+
+    act(() => {
+      result.current.setMessages([
+        new HumanMessage({ content: "hi", id: "1" }),
+        new AIMessage({
+          content: "partial answer",
+          id: "2",
+          additional_kwargs: { complete: false },
+        }),
+      ]);
+    });
+
+    expect(JSON.parse(sessionStorage.getItem("test_key") ?? "[]")).toEqual([
+      { type: "human", content: "hi", id: "1" },
+    ]);
+  });
+
+  it("persists and restores a complete AI message", () => {
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+
+    act(() => {
+      result.current.setMessages([
+        new AIMessage({
+          content: "complete answer",
+          id: "2",
+          additional_kwargs: { complete: true },
+        }),
+      ]);
+    });
+
+    expect(JSON.parse(sessionStorage.getItem("test_key") ?? "[]")).toEqual([
+      { type: "ai", content: "complete answer", id: "2", complete: true },
+    ]);
   });
 
   it("preserves and sends a guarded initial message in Strict Mode", async () => {
@@ -200,6 +263,21 @@ describe("useMessages", () => {
 
     expect(result.current.messages).toEqual([]);
     expect(sessionStorage.getItem("test_key")).toBeNull();
+  });
+
+  it("clearMessages resets state when sessionStorage removal is blocked", () => {
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+    act(() => {
+      result.current.setMessages([
+        new HumanMessage({ content: "hi", id: "1" }),
+      ]);
+    });
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new DOMException("Access denied", "SecurityError");
+    });
+
+    expect(() => act(() => result.current.clearMessages())).not.toThrow();
+    expect(result.current.messages).toEqual([]);
   });
 
   it("clearMessages without a storageKey only resets state", () => {

--- a/frontend/src/tests/hooks/useMessages.test.ts
+++ b/frontend/src/tests/hooks/useMessages.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect } from "vitest";
-import { deserializeAiMessage } from "../../hooks/useMessages";
+import React, { useEffect, useRef, useState } from "react";
+import { render, renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HumanMessage, AIMessage } from "@langchain/core/messages";
+import useMessages, { deserializeAiMessage } from "../../hooks/useMessages";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    QueryClientProvider,
+    { client: new QueryClient() },
+    children,
+  );
+}
 
 describe("deserializeAiMessage", () => {
   it("extracts text from a text chunk", () => {
@@ -26,5 +38,183 @@ describe("deserializeAiMessage", () => {
     expect(deserializeAiMessage(input)).toBe(
       "What was generated is just an initial template.",
     );
+  });
+});
+
+describe("useMessages", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts with empty messages when no storageKey is given", () => {
+    const { result } = renderHook(() => useMessages(), { wrapper });
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("starts with empty messages when storageKey has no entry", () => {
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("loads messages from sessionStorage on init", () => {
+    const stored = [
+      { type: "human", content: "hello", id: "1" },
+      { type: "ai", content: "world", id: "2" },
+    ];
+    sessionStorage.setItem("test_key", JSON.stringify(stored));
+
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[0]).toBeInstanceOf(HumanMessage);
+    expect(result.current.messages[1]).toBeInstanceOf(AIMessage);
+  });
+
+  it("persists messages to sessionStorage when they change", () => {
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+
+    act(() => {
+      result.current.setMessages([
+        new HumanMessage({ content: "hi", id: "1" }),
+      ]);
+    });
+
+    const stored = JSON.parse(sessionStorage.getItem("test_key") ?? "[]");
+    expect(stored).toEqual([{ type: "human", content: "hi", id: "1" }]);
+  });
+
+  it("preserves and sends a guarded initial message in Strict Mode", async () => {
+    const reader = {} as ReadableStreamDefaultReader<Uint8Array>;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      body: { getReader: () => reader },
+    } as Response);
+
+    function LetterBootstrap() {
+      const { messages, setMessages, addMessage } = useMessages(
+        "letter_messages:or-portland,",
+      );
+      const hasInitialized = useRef(false);
+      const [startStreaming, setStartStreaming] = useState(false);
+
+      useEffect(() => {
+        if (hasInitialized.current) return;
+        hasInitialized.current = true;
+        setMessages((previous) => [
+          ...previous,
+          new HumanMessage({ content: "Generate my letter", id: "1" }),
+        ]);
+        setStartStreaming(true);
+      }, [setMessages]);
+
+      useEffect(() => {
+        if (!startStreaming) return;
+        setStartStreaming(false);
+        void addMessage({ city: "portland", state: "or" });
+      }, [addMessage, startStreaming]);
+
+      return React.createElement(
+        "div",
+        { "data-testid": "message-count" },
+        messages.length,
+      );
+    }
+
+    const view = render(
+      React.createElement(
+        React.StrictMode,
+        null,
+        React.createElement(
+          QueryClientProvider,
+          { client: new QueryClient() },
+          React.createElement(LetterBootstrap),
+        ),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(view.getByTestId("message-count").textContent).toBe("1");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      JSON.parse(
+        sessionStorage.getItem("letter_messages:or-portland,") ?? "[]",
+      ),
+    ).toEqual([{ type: "human", content: "Generate my letter", id: "1" }]);
+
+    const request = fetchSpy.mock.calls[0]?.[1];
+    expect(JSON.parse(String(request?.body))).toEqual({
+      messages: [{ role: "human", content: "Generate my letter", id: "1" }],
+      city: "portland",
+      state: "or",
+    });
+  });
+
+  it("loads a new storage key without copying the previous conversation", async () => {
+    sessionStorage.setItem(
+      "second_key",
+      JSON.stringify([{ type: "human", content: "second", id: "2" }]),
+    );
+    const { result, rerender } = renderHook(
+      ({ storageKey }) => useMessages(storageKey),
+      {
+        initialProps: { storageKey: "first_key" },
+        wrapper,
+      },
+    );
+
+    act(() => {
+      result.current.setMessages([
+        new HumanMessage({ content: "first", id: "1" }),
+      ]);
+    });
+
+    rerender({ storageKey: "second_key" });
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0].text).toBe("second");
+    });
+
+    expect(JSON.parse(sessionStorage.getItem("first_key") ?? "[]")).toEqual([
+      { type: "human", content: "first", id: "1" },
+    ]);
+    expect(JSON.parse(sessionStorage.getItem("second_key") ?? "[]")).toEqual([
+      { type: "human", content: "second", id: "2" },
+    ]);
+  });
+
+  it("clearMessages resets state and removes the sessionStorage entry", () => {
+    sessionStorage.setItem(
+      "test_key",
+      JSON.stringify([{ type: "human", content: "hi", id: "1" }]),
+    );
+    const { result } = renderHook(() => useMessages("test_key"), { wrapper });
+
+    act(() => {
+      result.current.clearMessages();
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(sessionStorage.getItem("test_key")).toBeNull();
+  });
+
+  it("clearMessages without a storageKey only resets state", () => {
+    const { result } = renderHook(() => useMessages(), { wrapper });
+
+    act(() => {
+      result.current.setMessages([
+        new HumanMessage({ content: "hi", id: "1" }),
+      ]);
+    });
+
+    act(() => {
+      result.current.clearMessages();
+    });
+
+    expect(result.current.messages).toEqual([]);
   });
 });

--- a/frontend/src/tests/hooks/useMessages.test.ts
+++ b/frontend/src/tests/hooks/useMessages.test.ts
@@ -280,6 +280,37 @@ describe("useMessages", () => {
     expect(result.current.messages).toEqual([]);
   });
 
+  it("aborts an in-flight request when the storageKey changes mid-stream", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((_url, init) => {
+        capturedSignal = init?.signal ?? undefined;
+        // Never resolves — simulates a request still streaming when the
+        // jurisdiction (storageKey) changes underneath it.
+        return new Promise<Response>(() => {});
+      });
+
+    const { result, rerender } = renderHook(
+      ({ storageKey }) => useMessages(storageKey),
+      {
+        initialProps: { storageKey: "first_key" },
+        wrapper,
+      },
+    );
+
+    act(() => {
+      void result.current.addMessage({ city: "portland", state: "or" });
+    });
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    expect(capturedSignal?.aborted).toBe(false);
+
+    rerender({ storageKey: "second_key" });
+
+    await waitFor(() => expect(capturedSignal?.aborted).toBe(true));
+  });
+
   it("clearMessages without a storageKey only resets state", () => {
     const { result } = renderHook(() => useMessages(), { wrapper });
 

--- a/frontend/src/tests/utils/streamHelper.test.ts
+++ b/frontend/src/tests/utils/streamHelper.test.ts
@@ -61,7 +61,7 @@ describe("streamText", () => {
       city: "portland",
       state: "or",
     });
-    expect(mockSetMessages).toHaveBeenCalledTimes(3); // 1 initial + 2 chunk updates
+    expect(mockSetMessages).toHaveBeenCalledTimes(4); // Initial + 2 chunks + completion.
     expect(mockSetIsLoading).toHaveBeenCalledWith(true);
     expect(mockSetIsLoading).toHaveBeenCalledWith(false);
     expect(mockSetIsLoading).toHaveBeenCalledTimes(2);
@@ -83,7 +83,7 @@ describe("streamText", () => {
     } as StreamTextOptions);
 
     const calls = mockSetMessages.mock.calls;
-    const updateCall = calls[calls.length - 1][0];
+    const updateCall = calls[calls.length - 2][0];
     const existingMessages = [
       new HumanMessage({ content: "User message", id: "999" }),
       new AIMessage({ content: "First", id: "1000001" }),
@@ -136,11 +136,11 @@ describe("streamText", () => {
       setIsLoading: mockSetIsLoading,
     } as StreamTextOptions);
 
-    // 1 initial + 2 chunk updates (done chunk does not trigger setMessages)
-    expect(mockSetMessages).toHaveBeenCalledTimes(3);
+    // The done chunk marks the accumulated AI message complete.
+    expect(mockSetMessages).toHaveBeenCalledTimes(4);
 
     const lastCalls = mockSetMessages.mock.calls;
-    const lastUpdateCall = lastCalls[lastCalls.length - 1][0];
+    const lastUpdateCall = lastCalls[lastCalls.length - 2][0];
     const updated = lastUpdateCall([
       new AIMessage({ content: "", id: "1000001" }),
     ]);
@@ -217,6 +217,16 @@ describe("streamText", () => {
     } as StreamTextOptions);
 
     expect(mockOnDone).toHaveBeenCalledTimes(1);
+    const completionUpdate =
+      mockSetMessages.mock.calls[mockSetMessages.mock.calls.length - 1][0];
+    const completed = completionUpdate([
+      new AIMessage({
+        content: "answer",
+        id: "1000001",
+        additional_kwargs: { complete: false },
+      }),
+    ]);
+    expect(completed[0].additional_kwargs.complete).toBe(true);
   });
 
   it("should not call onDone when stream ends without a done chunk", async () => {
@@ -255,7 +265,7 @@ describe("streamText", () => {
     } as StreamTextOptions);
 
     const lastUpdateCall =
-      mockSetMessages.mock.calls[mockSetMessages.mock.calls.length - 1][0];
+      mockSetMessages.mock.calls[mockSetMessages.mock.calls.length - 2][0];
     const updated = lastUpdateCall([
       new AIMessage({ content: "", id: "1000001" }),
     ]);
@@ -278,7 +288,7 @@ describe("streamText", () => {
     } as StreamTextOptions);
 
     const lastUpdateCall =
-      mockSetMessages.mock.calls[mockSetMessages.mock.calls.length - 1][0];
+      mockSetMessages.mock.calls[mockSetMessages.mock.calls.length - 2][0];
     const updated = lastUpdateCall([
       new AIMessage({ content: "", id: "1000001" }),
     ]);
@@ -287,7 +297,7 @@ describe("streamText", () => {
     );
   });
 
-  it("should not call setMessages for the done chunk line", async () => {
+  it("should mark the bot message complete for the done chunk line", async () => {
     const mockReader = createMockReader([
       '{"type":"text","content":"Hello"}\n',
       '{"type":"end_of_stream"}\n',
@@ -300,7 +310,7 @@ describe("streamText", () => {
       housingLocation: { city: "portland", state: "or" },
     } as StreamTextOptions);
 
-    // 1 initial + 1 text chunk = 2 calls; done chunk adds no call.
-    expect(mockSetMessages).toHaveBeenCalledTimes(2);
+    // One initial message, one text update, and one completion update.
+    expect(mockSetMessages).toHaveBeenCalledTimes(3);
   });
 });

--- a/frontend/src/tests/utils/streamHelper.test.ts
+++ b/frontend/src/tests/utils/streamHelper.test.ts
@@ -121,6 +121,24 @@ describe("streamText", () => {
     expect(result[1].text).toContain("Sorry, I encountered an error");
   });
 
+  it("should silently stop without an error message when the request is aborted", async () => {
+    mockAddMessage.mockRejectedValue(
+      new DOMException("The user aborted a request.", "AbortError"),
+    );
+
+    await streamText({
+      addMessage: mockAddMessage,
+      setMessages: mockSetMessages,
+      housingLocation: { city: "portland", state: "or" },
+      setIsLoading: mockSetIsLoading,
+    } as StreamTextOptions);
+
+    expect(mockSetIsLoading).toHaveBeenCalledWith(false);
+    expect(console.error).not.toHaveBeenCalled();
+    // Only the initial empty placeholder was added — no error message patched in.
+    expect(mockSetMessages).toHaveBeenCalledTimes(1);
+  });
+
   it("should accumulate reasoning and text chunks in order", async () => {
     const mockReader = createMockReader([
       '{"type":"reasoning","content":"Let me think."}\n',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Infrastructure
- [ ] Maintenance

## Description

Persists chat and letter message history to `sessionStorage` so an in-progress conversation survives a page refresh within the same browser tab session, instead of being lost.

This reimplements the `sessionStorage-chat-message-history` branch on top of current `main` (that branch had drifted 29 commits behind and was retired rather than rebased).

- `useMessages` now accepts an optional `storageKey`; when given, it loads messages from `sessionStorage` on mount and syncs every state change back to it.
- `Chat.tsx` keys storage by jurisdiction (`chat_messages:`); `Letter.tsx` keys it by jurisdiction + referring org (`letter_messages:,`), so switching location or partner link starts a fresh conversation.
- `Letter.tsx` skips re-generating the letter on mount when a restored session already has a completed letter, and avoids duplicating the initial prompt on an incomplete restored session.
- `MessageWindow.tsx` now takes an explicit `mode: "chat" | "letter"` prop (replacing a `useLocation` pathname check) and a `clearMessages` callback, so "Clear" now clears the stored session (and reloads, for letters) instead of just reloading the page.
- Added `frontend/src/shared/utils/reloadPage.ts` as a thin, testable wrapper around `window.location.reload()`.

`DevicePrivacyGuard`:

- Wraps the `/chat` and `/letter` routes and, on first visit, asks whether the device is public or private (stored in `sessionStorage` via new `readSessionStorage`/`writeSessionStorage` helpers in `storage.ts`).
- On a device marked public, tracks user activity (click/keydown/mousemove/scroll/touchstart) and, after 5 minutes idle, shows a 120-second "Are you still there?" warning.
- If the warning expires with no response, it clears `sessionStorage`, attempts to close the tab, and falls back to redirecting to `/` (browsers only allow scripts to close tabs they opened).

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

1. Start a chat conversation on `/chat/or/portland`, send a message, then refresh the page — the conversation should still be there.
2. Start a letter on `/letter/or/portland`, let it finish generating, then refresh — the completed letter should be restored without regenerating.
3. Refresh mid-generation (before the letter completes) — it should retry without duplicating the initial prompt.
4. Click "Clear" on chat — history should be gone and `sessionStorage` for that key cleared.
5. Click "Clear" on a letter — history should clear and the page should reload.
6. Navigate between jurisdictions (e.g. Portland → Eugene) — each should have its own independent conversation, not share one.
7. Visit `/chat` or `/letter` in a fresh tab — you should be prompted to choose "Public device" or "Private device" before the page renders.
8. Choose "Private device" — no idle warning should appear.
9. Choose "Public device", then dawdle around for 5 minutes — a 120-second countdown warning should appear; moving the mouse/typing before then should reset the idle timer instead.
10. Let the countdown reach 0 — `sessionStorage` should be cleared and the tab should close or redirect to `/`. Clicking "Cancel" during the countdown should dismiss the warning and resume normal use.

## Added/updated tests?

- [x] Yes

Updated `useMessages.test.ts`, `Letter.test.tsx`, and `MessageWindow.test.tsx` to cover sessionStorage load/persist/clear behavior, storage-key switching, restored-letter handling, and the new `mode`/`clearMessages` props. Added `DevicePrivacyGuard.test.tsx` to cover the public/private choice, idle-warning trigger, and activity-based timer reset. Full suite passing. `tsc --noEmit`, `eslint`, and `prettier --check` are all clean.

## Documentation

- [x] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?

None.
